### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/avifenesh/awesome-slash/security/code-scanning/7](https://github.com/avifenesh/awesome-slash/security/code-scanning/7)

In general, the problem is fixed by explicitly specifying a least-privilege `permissions` block for the workflow or for each job. Since this workflow only checks out code, sets up Node, installs dependencies, and runs tests and local Node scripts, it only needs read access to repository contents. Therefore, we should add `permissions: contents: read` at the workflow root so it applies to all jobs (there is only one job, `test`).

Concretely, in `.github/workflows/ci.yml`, add a `permissions` block at the top level between the `name: CI` and `on:` keys. This keeps existing behavior (CI steps still run as before) while ensuring that the `GITHUB_TOKEN` has only read access to repository contents and no unnecessary write privileges. No additional imports, methods, or other definitions are required; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
