### PR TITLE
chore: release v4.2.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "awesome-slash",
   "description": "12 specialized plugins for AI workflow automation - task orchestration, PR workflow, slop detection, code review, drift detection, enhancement analysis, documentation sync, repo mapping, perf investigations, topic research, agent config linting, and cross-tool AI consultation",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "owner": {
     "name": "Avi Fenesh",
     "url": "https://github.com/avifenesh"
@@ -26,84 +26,84 @@
       "name": "next-task",
       "source": "./plugins/next-task",
       "description": "Master workflow orchestrator: autonomous workflow with model optimization (opus/sonnet/haiku), two-file state management, workflow enforcement gates, 14 specialist agents",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "category": "productivity"
     },
     {
       "name": "ship",
       "source": "./plugins/ship",
       "description": "Complete PR workflow: commit to production, skips review when called from next-task, removes task from registry on cleanup, automatic rollback",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "category": "deployment"
     },
     {
       "name": "deslop",
       "source": "./plugins/deslop",
       "description": "3-phase AI slop detection: regex patterns (HIGH), multi-pass analyzers (MEDIUM), CLI tools (LOW)",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "category": "development"
     },
     {
       "name": "audit-project",
       "source": "./plugins/audit-project",
       "description": "Multi-agent iterative code review until zero issues remain",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "category": "development"
     },
     {
       "name": "drift-detect",
       "source": "./plugins/drift-detect",
       "description": "Deep repository analysis to realign project plans with code reality - detects drift, gaps, and creates prioritized reconstruction plans",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "category": "productivity"
     },
     {
       "name": "enhance",
       "source": "./plugins/enhance",
       "description": "Master enhancement orchestrator: parallel analyzer execution for plugins, agents, docs, CLAUDE.md, and prompts with unified reporting",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "category": "development"
     },
     {
       "name": "sync-docs",
       "source": "./plugins/sync-docs",
       "description": "Standalone documentation sync: find outdated refs, update CHANGELOG, flag stale examples based on code changes",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "category": "development"
     },
     {
       "name": "repo-map",
       "source": "./plugins/repo-map",
       "description": "AST-based repository map generation using ast-grep with incremental updates for faster drift analysis",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "category": "development"
     },
     {
       "name": "perf",
       "source": "./plugins/perf",
       "description": "Rigorous performance investigation workflow with baselines, profiling, hypotheses, and evidence-backed decisions",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "category": "development"
     },
     {
       "name": "learn",
       "source": "./plugins/learn",
       "description": "Research topics online and create comprehensive learning guides with RAG-optimized indexes",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "category": "productivity"
     },
     {
       "name": "agnix",
       "source": "./plugins/agnix",
       "description": "Lint agent configuration files (SKILL.md, CLAUDE.md, hooks, MCP) against 155 rules across 10+ AI tools",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "category": "development"
     },
     {
       "name": "consult",
       "source": "./plugins/consult",
       "description": "Cross-tool AI consultation: get second opinions from Gemini CLI, Codex CLI, Claude Code, OpenCode, or Copilot CLI with model and thinking effort control",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "category": "productivity"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-slash",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Professional-grade slash commands for Claude Code with cross-platform support",
   "keywords": [
     "workflow",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.2] - 2026-02-12
+
+### Fixed
+- Added missing frontmatter descriptions to 3 command reference files (`audit-project-agents`, `ship-ci-review-loop`, `ship-deployment`) that caused Codex adapter skills to install with empty descriptions
+- Added build-time validation in `gen-adapters.js` to error on empty Codex skill descriptions
+- Added install-time guard in `bin/cli.js` to skip skills with missing descriptions
+
 ## [4.2.1] - 2026-02-11
 
 ### Fixed

--- a/adapters/opencode/skills/agnix/SKILL.md
+++ b/adapters/opencode/skills/agnix/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: agnix
 description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 155 rules across 10+ AI tools."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[path] [--fix] [--strict] [--target=claude-code|cursor|codex]"
 ---
 

--- a/adapters/opencode/skills/consult/SKILL.md
+++ b/adapters/opencode/skills/consult/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: consult
 description: "Cross-tool AI consultation. Use when user asks to 'consult gemini', 'ask codex', 'get second opinion', 'cross-check with claude', 'consult another AI', 'ask opencode', 'copilot opinion', or wants a second opinion from a different AI tool."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[question] [--tool] [--effort] [--model] [--context] [--continue]"
 ---
 

--- a/adapters/opencode/skills/deslop/SKILL.md
+++ b/adapters/opencode/skills/deslop/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: deslop
 description: "Use when user wants to clean AI slop from code. Use for cleanup, remove debug statements, find ghost code, repo hygiene."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[report|apply] [--scope=all|diff|path] [--thoroughness=quick|normal|deep]"
 ---
 

--- a/adapters/opencode/skills/discover-tasks/SKILL.md
+++ b/adapters/opencode/skills/discover-tasks/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: discover-tasks
 description: "Use when discovering and prioritizing tasks from configured sources. Handles GitHub, GitLab, local files, and custom sources."
-version: 4.2.1
+version: 4.2.2
 ---
 
 # discover-tasks

--- a/adapters/opencode/skills/drift-analysis/SKILL.md
+++ b/adapters/opencode/skills/drift-analysis/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: drift-analysis
 description: Use when the user asks about plan drift, reality check, comparing docs to code, project state analysis, roadmap alignment, implementation gaps, or needs guidance on identifying discrepancies between documented plans and actual implementation state.
-version: 4.2.1
+version: 4.2.2
 ---
 
 # Drift Analysis

--- a/adapters/opencode/skills/enhance-agent-prompts/SKILL.md
+++ b/adapters/opencode/skills/enhance-agent-prompts/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: enhance-agent-prompts
 description: "Use when improving agent prompts, frontmatter, and tool restrictions."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[path] [--fix] [--verbose]"
 ---
 

--- a/adapters/opencode/skills/enhance-claude-memory/SKILL.md
+++ b/adapters/opencode/skills/enhance-claude-memory/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: enhance-claude-memory
 description: "Use when improving CLAUDE.md or AGENTS.md project memory files."
-version: 4.2.1
+version: 4.2.2
 ---
 
 > **OpenCode Note**: Invoke agents using `@agent-name` syntax.

--- a/adapters/opencode/skills/enhance-cross-file/SKILL.md
+++ b/adapters/opencode/skills/enhance-cross-file/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: enhance-cross-file
 description: "Use when checking cross-file consistency: tools vs frontmatter, agent references, duplicate rules, contradictions."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[path]"
 ---
 

--- a/adapters/opencode/skills/enhance-docs/SKILL.md
+++ b/adapters/opencode/skills/enhance-docs/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: enhance-docs
 description: "Use when improving documentation structure, accuracy, and RAG readiness."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[path] [--fix] [--ai]"
 ---
 

--- a/adapters/opencode/skills/enhance-hooks/SKILL.md
+++ b/adapters/opencode/skills/enhance-hooks/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: enhance-hooks
 description: "Use when reviewing hooks for safety, timeouts, and correct frontmatter."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[path] [--fix]"
 ---
 

--- a/adapters/opencode/skills/enhance-orchestrator/SKILL.md
+++ b/adapters/opencode/skills/enhance-orchestrator/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: enhance-orchestrator
 description: "Use when coordinating multiple enhancers for /enhance command. Runs analyzers in parallel and produces unified report."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[path] [--apply] [--focus=TYPE]"
 ---
 

--- a/adapters/opencode/skills/enhance-plugins/SKILL.md
+++ b/adapters/opencode/skills/enhance-plugins/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: enhance-plugins
 description: "Use when analyzing plugin structures, MCP tools, and plugin security patterns."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[path] [--fix]"
 ---
 

--- a/adapters/opencode/skills/enhance-prompts/SKILL.md
+++ b/adapters/opencode/skills/enhance-prompts/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: enhance-prompts
 description: "Use when improving general prompts for structure, examples, and constraints."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[path] [--fix]"
 ---
 

--- a/adapters/opencode/skills/enhance-skills/SKILL.md
+++ b/adapters/opencode/skills/enhance-skills/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: enhance-skills
 description: "Use when reviewing SKILL.md files for structure and trigger quality."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[path] [--fix]"
 ---
 

--- a/adapters/opencode/skills/learn/SKILL.md
+++ b/adapters/opencode/skills/learn/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: learn
 description: "Research any topic online and create learning guides. Use when user asks to 'learn about', 'research topic', 'create learning guide', 'build knowledge base', or 'study subject'."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[topic] [--depth=brief|medium|deep]"
 ---
 

--- a/adapters/opencode/skills/perf-analyzer/SKILL.md
+++ b/adapters/opencode/skills/perf-analyzer/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: perf-analyzer
 description: "Use when synthesizing perf findings into evidence-backed recommendations and decisions."
-version: 4.2.1
+version: 4.2.2
 ---
 
 # perf-analyzer

--- a/adapters/opencode/skills/perf-baseline-manager/SKILL.md
+++ b/adapters/opencode/skills/perf-baseline-manager/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: perf-baseline-manager
 description: "Use when managing perf baselines, consolidating results, or comparing versions. Ensures one baseline JSON per version."
-version: 4.2.1
+version: 4.2.2
 ---
 
 # perf-baseline-manager

--- a/adapters/opencode/skills/perf-benchmarker/SKILL.md
+++ b/adapters/opencode/skills/perf-benchmarker/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: perf-benchmarker
 description: "Use when running performance benchmarks, establishing baselines, or validating regressions with sequential runs. Enforces 60s minimum runs (30s only for binary search) and no parallel benchmarks."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[command] [duration]"
 ---
 

--- a/adapters/opencode/skills/perf-code-paths/SKILL.md
+++ b/adapters/opencode/skills/perf-code-paths/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: perf-code-paths
 description: "Use when mapping code paths, entrypoints, and likely hot files before profiling."
-version: 4.2.1
+version: 4.2.2
 ---
 
 # perf-code-paths

--- a/adapters/opencode/skills/perf-investigation-logger/SKILL.md
+++ b/adapters/opencode/skills/perf-investigation-logger/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: perf-investigation-logger
 description: "Use when appending structured perf investigation notes and evidence."
-version: 4.2.1
+version: 4.2.2
 ---
 
 # perf-investigation-logger

--- a/adapters/opencode/skills/perf-profiler/SKILL.md
+++ b/adapters/opencode/skills/perf-profiler/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: perf-profiler
 description: "Use when profiling CPU/memory hot paths, generating flame graphs, or capturing JFR/perf evidence."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[tool] [command]"
 ---
 

--- a/adapters/opencode/skills/perf-theory-gatherer/SKILL.md
+++ b/adapters/opencode/skills/perf-theory-gatherer/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: perf-theory-gatherer
 description: "Use when generating performance hypotheses backed by git history and code evidence."
-version: 4.2.1
+version: 4.2.2
 ---
 
 # perf-theory-gatherer

--- a/adapters/opencode/skills/perf-theory-tester/SKILL.md
+++ b/adapters/opencode/skills/perf-theory-tester/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: perf-theory-tester
 description: "Use when running controlled perf experiments to validate hypotheses."
-version: 4.2.1
+version: 4.2.2
 ---
 
 # perf-theory-tester

--- a/adapters/opencode/skills/sync-docs/SKILL.md
+++ b/adapters/opencode/skills/sync-docs/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: sync-docs
 description: "Sync documentation with code. Use when user asks to update docs, check docs, fix stale documentation, update changelog, or after code changes."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[report|apply] [--scope=all|recent|before-pr] [--include-undocumented]"
 allowed-tools: Bash(git:*), Read, Grep, Glob
 ---

--- a/adapters/opencode/skills/validate-delivery/SKILL.md
+++ b/adapters/opencode/skills/validate-delivery/SKILL.md
@@ -2,7 +2,7 @@
 ---
 name: validate-delivery
 description: "Use when validating task completion before shipping. Runs tests, build, and requirement checks. Returns pass/fail with fix instructions."
-version: 4.2.1
+version: 4.2.2
 ---
 
 # validate-delivery

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "awesome-slash",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "awesome-slash",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "license": "MIT",
       "workspaces": [
         "lib"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-slash",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "12 specialized plugins for AI workflow automation (drift detection + AST repo maps + topic research + agent config linting) - works with Claude Code, OpenCode, and Codex CLI",
   "main": "lib/platform/detect-platform.js",
   "type": "commonjs",

--- a/plugins/agnix/.claude-plugin/plugin.json
+++ b/plugins/agnix/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agnix",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Lint agent configurations before they break your workflow. Validates Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",

--- a/plugins/agnix/skills/agnix/SKILL.md
+++ b/plugins/agnix/skills/agnix/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agnix
 description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 155 rules across 10+ AI tools."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[path] [--fix] [--strict] [--target=claude-code|cursor|codex]"
 ---
 

--- a/plugins/audit-project/.claude-plugin/plugin.json
+++ b/plugins/audit-project/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-project",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Multi-agent iterative code review until zero issues remain",
   "author": {
     "name": "Avi Fenesh",

--- a/plugins/audit-project/commands/audit-project-agents.md
+++ b/plugins/audit-project/commands/audit-project-agents.md
@@ -1,5 +1,6 @@
 ---
 description: "Use when coordinating multi-agent review passes in /audit-project. Details agent specialization, file filtering, and review queue handling."
+codex-description: "Use when coordinating multi-agent review passes in /audit-project. Details agent specialization, file filtering, and review queue handling."
 ---
 
 # Phase 2: Multi-Agent Review - Reference

--- a/plugins/consult/.claude-plugin/plugin.json
+++ b/plugins/consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "consult",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Cross-tool AI consultation: get second opinions from Gemini, Codex, Claude, OpenCode, or Copilot CLI",
   "author": {
     "name": "Avi Fenesh",

--- a/plugins/consult/skills/consult/SKILL.md
+++ b/plugins/consult/skills/consult/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: consult
 description: "Cross-tool AI consultation. Use when user asks to 'consult gemini', 'ask codex', 'get second opinion', 'cross-check with claude', 'consult another AI', 'ask opencode', 'copilot opinion', or wants a second opinion from a different AI tool."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[question] [--tool] [--effort] [--model] [--context] [--continue]"
 ---
 

--- a/plugins/deslop/.claude-plugin/plugin.json
+++ b/plugins/deslop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deslop",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "AI slop cleanup with minimal diffs and behavior preservation",
   "author": {
     "name": "Avi Fenesh",

--- a/plugins/deslop/skills/deslop/SKILL.md
+++ b/plugins/deslop/skills/deslop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deslop
 description: "Use when user wants to clean AI slop from code. Use for cleanup, remove debug statements, find ghost code, repo hygiene."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[report|apply] [--scope=all|diff|path] [--thoroughness=quick|normal|deep]"
 ---
 

--- a/plugins/drift-detect/.claude-plugin/plugin.json
+++ b/plugins/drift-detect/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "drift-detect",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Deep repository analysis to realign project plans with actual code reality - discovers drift, gaps, and produces prioritized reconstruction plans",
   "author": {
     "name": "Avi Fenesh",

--- a/plugins/drift-detect/skills/drift-analysis/SKILL.md
+++ b/plugins/drift-detect/skills/drift-analysis/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: drift-analysis
 description: Use when the user asks about plan drift, reality check, comparing docs to code, project state analysis, roadmap alignment, implementation gaps, or needs guidance on identifying discrepancies between documented plans and actual implementation state.
-version: 4.2.1
+version: 4.2.2
 ---
 
 # Drift Analysis

--- a/plugins/enhance/.claude-plugin/plugin.json
+++ b/plugins/enhance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "enhance",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Plugin structure and tool use analyzer - validates plugin.json, MCP tools, and security patterns",
   "author": {
     "name": "Avi Fenesh",

--- a/plugins/enhance/skills/enhance-agent-prompts/SKILL.md
+++ b/plugins/enhance/skills/enhance-agent-prompts/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: enhance-agent-prompts
 description: "Use when improving agent prompts, frontmatter, and tool restrictions."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[path] [--fix] [--verbose]"
 ---
 

--- a/plugins/enhance/skills/enhance-claude-memory/SKILL.md
+++ b/plugins/enhance/skills/enhance-claude-memory/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: enhance-claude-memory
 description: "Use when improving CLAUDE.md or AGENTS.md project memory files."
-version: 4.2.1
+version: 4.2.2
 ---
 
 # enhance-claude-memory

--- a/plugins/enhance/skills/enhance-cross-file/SKILL.md
+++ b/plugins/enhance/skills/enhance-cross-file/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: enhance-cross-file
 description: "Use when checking cross-file consistency: tools vs frontmatter, agent references, duplicate rules, contradictions."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[path]"
 ---
 

--- a/plugins/enhance/skills/enhance-docs/SKILL.md
+++ b/plugins/enhance/skills/enhance-docs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: enhance-docs
 description: "Use when improving documentation structure, accuracy, and RAG readiness."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[path] [--fix] [--ai]"
 ---
 

--- a/plugins/enhance/skills/enhance-hooks/SKILL.md
+++ b/plugins/enhance/skills/enhance-hooks/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: enhance-hooks
 description: "Use when reviewing hooks for safety, timeouts, and correct frontmatter."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[path] [--fix]"
 ---
 

--- a/plugins/enhance/skills/enhance-orchestrator/SKILL.md
+++ b/plugins/enhance/skills/enhance-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: enhance-orchestrator
 description: "Use when coordinating multiple enhancers for /enhance command. Runs analyzers in parallel and produces unified report."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[path] [--apply] [--focus=TYPE]"
 ---
 

--- a/plugins/enhance/skills/enhance-plugins/SKILL.md
+++ b/plugins/enhance/skills/enhance-plugins/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: enhance-plugins
 description: "Use when analyzing plugin structures, MCP tools, and plugin security patterns."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[path] [--fix]"
 ---
 

--- a/plugins/enhance/skills/enhance-prompts/SKILL.md
+++ b/plugins/enhance/skills/enhance-prompts/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: enhance-prompts
 description: "Use when improving general prompts for structure, examples, and constraints."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[path] [--fix]"
 ---
 

--- a/plugins/enhance/skills/enhance-skills/SKILL.md
+++ b/plugins/enhance/skills/enhance-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: enhance-skills
 description: "Use when reviewing SKILL.md files for structure and trigger quality."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[path] [--fix]"
 ---
 

--- a/plugins/learn/.claude-plugin/plugin.json
+++ b/plugins/learn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "learn",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Research any topic online and create comprehensive learning guides with RAG-optimized indexes",
   "author": {
     "name": "Avi Fenesh",

--- a/plugins/learn/skills/learn/SKILL.md
+++ b/plugins/learn/skills/learn/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: learn
 description: "Research any topic online and create learning guides. Use when user asks to 'learn about', 'research topic', 'create learning guide', 'build knowledge base', or 'study subject'."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[topic] [--depth=brief|medium|deep]"
 ---
 

--- a/plugins/next-task/.claude-plugin/plugin.json
+++ b/plugins/next-task/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "next-task",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Master workflow orchestrator with autonomous task-to-production automation, quality gates, and multi-agent review",
   "author": {
     "name": "Avi Fenesh",

--- a/plugins/next-task/skills/discover-tasks/SKILL.md
+++ b/plugins/next-task/skills/discover-tasks/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: discover-tasks
 description: "Use when discovering and prioritizing tasks from configured sources. Handles GitHub, GitLab, local files, and custom sources."
-version: 4.2.1
+version: 4.2.2
 ---
 
 # discover-tasks

--- a/plugins/next-task/skills/validate-delivery/SKILL.md
+++ b/plugins/next-task/skills/validate-delivery/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: validate-delivery
 description: "Use when validating task completion before shipping. Runs tests, build, and requirement checks. Returns pass/fail with fix instructions."
-version: 4.2.1
+version: 4.2.2
 ---
 
 # validate-delivery

--- a/plugins/perf/.claude-plugin/plugin.json
+++ b/plugins/perf/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "perf",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Rigorous performance investigation workflow with baselines, profiling, and evidence-backed decisions",
   "author": {
     "name": "Avi Fenesh",

--- a/plugins/perf/skills/perf-analyzer/SKILL.md
+++ b/plugins/perf/skills/perf-analyzer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: perf-analyzer
 description: "Use when synthesizing perf findings into evidence-backed recommendations and decisions."
-version: 4.2.1
+version: 4.2.2
 ---
 
 # perf-analyzer

--- a/plugins/perf/skills/perf-baseline-manager/SKILL.md
+++ b/plugins/perf/skills/perf-baseline-manager/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: perf-baseline-manager
 description: "Use when managing perf baselines, consolidating results, or comparing versions. Ensures one baseline JSON per version."
-version: 4.2.1
+version: 4.2.2
 ---
 
 # perf-baseline-manager

--- a/plugins/perf/skills/perf-benchmarker/SKILL.md
+++ b/plugins/perf/skills/perf-benchmarker/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: perf-benchmarker
 description: "Use when running performance benchmarks, establishing baselines, or validating regressions with sequential runs. Enforces 60s minimum runs (30s only for binary search) and no parallel benchmarks."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[command] [duration]"
 ---
 

--- a/plugins/perf/skills/perf-code-paths/SKILL.md
+++ b/plugins/perf/skills/perf-code-paths/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: perf-code-paths
 description: "Use when mapping code paths, entrypoints, and likely hot files before profiling."
-version: 4.2.1
+version: 4.2.2
 ---
 
 # perf-code-paths

--- a/plugins/perf/skills/perf-investigation-logger/SKILL.md
+++ b/plugins/perf/skills/perf-investigation-logger/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: perf-investigation-logger
 description: "Use when appending structured perf investigation notes and evidence."
-version: 4.2.1
+version: 4.2.2
 ---
 
 # perf-investigation-logger

--- a/plugins/perf/skills/perf-profiler/SKILL.md
+++ b/plugins/perf/skills/perf-profiler/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: perf-profiler
 description: "Use when profiling CPU/memory hot paths, generating flame graphs, or capturing JFR/perf evidence."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[tool] [command]"
 ---
 

--- a/plugins/perf/skills/perf-theory-gatherer/SKILL.md
+++ b/plugins/perf/skills/perf-theory-gatherer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: perf-theory-gatherer
 description: "Use when generating performance hypotheses backed by git history and code evidence."
-version: 4.2.1
+version: 4.2.2
 ---
 
 # perf-theory-gatherer

--- a/plugins/perf/skills/perf-theory-tester/SKILL.md
+++ b/plugins/perf/skills/perf-theory-tester/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: perf-theory-tester
 description: "Use when running controlled perf experiments to validate hypotheses."
-version: 4.2.1
+version: 4.2.2
 ---
 
 # perf-theory-tester

--- a/plugins/repo-map/.claude-plugin/plugin.json
+++ b/plugins/repo-map/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-map",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "AST-based repository map generator using ast-grep for symbol and import extraction with incremental updates",
   "author": {
     "name": "Avi Fenesh",

--- a/plugins/ship/.claude-plugin/plugin.json
+++ b/plugins/ship/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Complete PR workflow from commit to production with validation",
   "author": {
     "name": "Avi Fenesh",

--- a/plugins/ship/commands/ship-ci-review-loop.md
+++ b/plugins/ship/commands/ship-ci-review-loop.md
@@ -1,5 +1,6 @@
 ---
 description: "Use when monitoring CI and handling review comments during /ship. Details mandatory wait periods, auto-reviewer handling, and comment resolution."
+codex-description: "Use when monitoring CI and handling review comments during /ship. Details mandatory wait periods, auto-reviewer handling, and comment resolution."
 ---
 
 <ci-review-loop>

--- a/plugins/ship/commands/ship-deployment.md
+++ b/plugins/ship/commands/ship-deployment.md
@@ -1,5 +1,6 @@
 ---
 description: "Use when deploying and validating during /ship. Details Railway/Vercel deployment, smoke testing, and rollback procedures."
+codex-description: "Use when deploying and validating during /ship. Details Railway/Vercel deployment, smoke testing, and rollback procedures."
 ---
 
 # Phases 7-10: Deploy & Validate - Reference

--- a/plugins/sync-docs/.claude-plugin/plugin.json
+++ b/plugins/sync-docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sync-docs",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Sync documentation with code changes. Find outdated refs, update CHANGELOG, flag stale examples.",
   "author": {
     "name": "Avi Fenesh",

--- a/plugins/sync-docs/skills/sync-docs/SKILL.md
+++ b/plugins/sync-docs/skills/sync-docs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: sync-docs
 description: "Sync documentation with code. Use when user asks to update docs, check docs, fix stale documentation, update changelog, or after code changes."
-version: 4.2.1
+version: 4.2.2
 argument-hint: "[report|apply] [--scope=all|recent|before-pr] [--include-undocumented]"
 allowed-tools: Bash(git:*), Read, Grep, Glob
 ---

--- a/site/content.json
+++ b/site/content.json
@@ -5,7 +5,7 @@
     "url": "https://avifenesh.github.io/awesome-slash",
     "repo": "https://github.com/avifenesh/awesome-slash",
     "npm": "https://www.npmjs.com/package/awesome-slash",
-    "version": "4.2.1",
+    "version": "4.2.2",
     "author": "Avi Fenesh",
     "author_url": "https://github.com/avifenesh"
   },


### PR DESCRIPTION
## Summary

- Version bump to 4.2.2 across all manifests, skills, and adapters
- Added `codex-description` frontmatter to 3 command reference files for preflight compliance
- CHANGELOG.md updated with v4.2.2 entry

### Changes in this release (from #212)
- Fixed missing frontmatter descriptions on `audit-project-agents`, `ship-ci-review-loop`, `ship-deployment` command files
- Added build-time guard in `gen-adapters.js` to error on empty Codex skill descriptions
- Added install-time guard in `bin/cli.js` to skip skills with missing descriptions

## Test plan

- [x] `npm test` - 92 suites, 3917 tests pass (including preflight test)
- [x] `npm run validate` - all validators pass
- [x] Adapters regenerated and up to date