### PR TITLE
fix: update all repo links from avifenesh to agent-sh org

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
     "name": "Avi Fenesh",
     "url": "https://github.com/avifenesh"
   },
-  "repository": "https://github.com/avifenesh/agentsys",
+  "repository": "https://github.com/agent-sh/agentsys",
   "keywords": [
     "ai",
     "llm",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -15,6 +15,6 @@
     "name": "Avi Fenesh",
     "url": "https://github.com/avifenesh"
   },
-  "repository": "https://github.com/avifenesh/agentsys",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT"
 }

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Discussions
-    url: https://github.com/avifenesh/agentsys/discussions
+    url: https://github.com/agent-sh/agentsys/discussions
     about: Ask questions and share ideas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,7 +163,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added CI/CD integration example with GitHub Code Scanning SARIF workflow
   - Added installation instructions (Cargo, Homebrew)
   - Added "Why use agnix" value proposition section
-  - Prominent link to [agnix CLI project](https://github.com/avifenesh/agnix)
+  - Prominent link to [agnix CLI project](https://github.com/agent-sh/agnix)
   - Updated Commands table with more descriptive entry
   - Updated skill count to 26 across all references
 
@@ -183,7 +183,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Auto-fix support with `--fix` flag
   - SARIF output for GitHub Code Scanning integration
   - Target-specific validation (`--target claude-code|cursor|codex`)
-  - Requires [agnix CLI](https://github.com/avifenesh/agnix) (`cargo install agnix-cli`)
+  - Requires [agnix CLI](https://github.com/agent-sh/agnix) (`cargo install agnix-cli`)
 
 ### Changed
 - **Plugin Count** - Now 11 plugins, 40 agents, 26 skills
@@ -247,6 +247,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Previous Releases
 
-- [v3.x Changelog](https://github.com/avifenesh/agentsys/blob/main/changelogs/CHANGELOG-v3.md) (v3.0.0 - v3.9.0)
-- [v2.x Changelog](https://github.com/avifenesh/agentsys/blob/main/changelogs/CHANGELOG-v2.md) (v2.0.0 - v2.10.1)
-- [v1.x Changelog](https://github.com/avifenesh/agentsys/blob/main/changelogs/CHANGELOG-v1.md) (v1.0.0 - v1.1.0)
+- [v3.x Changelog](https://github.com/agent-sh/agentsys/blob/main/changelogs/CHANGELOG-v3.md) (v3.0.0 - v3.9.0)
+- [v2.x Changelog](https://github.com/agent-sh/agentsys/blob/main/changelogs/CHANGELOG-v2.md) (v2.0.0 - v2.10.1)
+- [v1.x Changelog](https://github.com/agent-sh/agentsys/blob/main/changelogs/CHANGELOG-v1.md) (v1.0.0 - v1.1.0)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,5 +158,5 @@ Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
 
 ## Getting Help
 
-- **Questions**: [Discussions](https://github.com/avifenesh/agentsys/discussions)
-- **Bugs**: [Issues](https://github.com/avifenesh/agentsys/issues)
+- **Questions**: [Discussions](https://github.com/agent-sh/agentsys/discussions)
+- **Bugs**: [Issues](https://github.com/agent-sh/agentsys/issues)

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/agentsys"><img src="https://img.shields.io/npm/v/agentsys.svg" alt="npm version"></a>
   <a href="https://www.npmjs.com/package/agentsys"><img src="https://img.shields.io/npm/dm/agentsys.svg" alt="npm downloads"></a>
-  <a href="https://github.com/avifenesh/agentsys/actions/workflows/ci.yml"><img src="https://github.com/avifenesh/agentsys/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://github.com/avifenesh/agentsys/stargazers"><img src="https://img.shields.io/github/stars/avifenesh/agentsys.svg" alt="GitHub stars"></a>
+  <a href="https://github.com/agent-sh/agentsys/actions/workflows/ci.yml"><img src="https://github.com/agent-sh/agentsys/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/agent-sh/agentsys/stargazers"><img src="https://img.shields.io/github/stars/agent-sh/agentsys.svg" alt="GitHub stars"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
-  <a href="https://avifenesh.github.io/agentsys/"><img src="https://img.shields.io/badge/Website-AgentSys-blue?style=flat&logo=github" alt="Website"></a>
+  <a href="https://agent-sh.github.io/agentsys/"><img src="https://img.shields.io/badge/Website-AgentSys-blue?style=flat&logo=github" alt="Website"></a>
   <a href="https://github.com/hesreallyhim/awesome-claude-code"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Claude Code"></a>
 </p>
 
@@ -25,7 +25,7 @@
 </p>
 
 <p align="center">
-  <a href="#commands">Commands</a> · <a href="#installation">Installation</a> · <a href="https://avifenesh.github.io/agentsys/">Website</a> · <a href="https://github.com/avifenesh/agentsys/discussions">Discussions</a>
+  <a href="#commands">Commands</a> · <a href="#installation">Installation</a> · <a href="https://agent-sh.github.io/agentsys/">Website</a> · <a href="https://github.com/agent-sh/agentsys/discussions">Discussions</a>
 </p>
 
 <p align="center">
@@ -42,7 +42,7 @@
 AI models can write code. That's not the hard part anymore. The hard part is everything around it — task selection, branch management, code review, artifact cleanup, CI, PR comments, deployment. **AgentSys is the runtime that orchestrates agents to handle all of it** — structured pipelines, gated phases, specialized agents, and persistent state that survives session boundaries.
 
 ---
-> Building custom skills, agents, hooks, or MCP tools? [agnix](https://github.com/avifenesh/agnix) is the CLI + LSP linter that catches config errors before they fail silently - real-time IDE validation, auto suggestions, auto-fix, and 155 rules for Cursor, Claude Code, Cline, Copilot, Codex, Windsurf, and more.
+> Building custom skills, agents, hooks, or MCP tools? [agnix](https://github.com/agent-sh/agnix) is the CLI + LSP linter that catches config errors before they fail silently - real-time IDE validation, auto suggestions, auto-fix, and 155 rules for Cursor, Claude Code, Cline, Copilot, Codex, Windsurf, and more.
 
 ## What This Is
 
@@ -196,7 +196,7 @@ Phase 9 uses the `orchestrate-review` skill to spawn parallel reviewers (code qu
 
 **Purpose:** Lint agent configurations before they break your workflow. The first dedicated linter for AI agent configs.
 
-**[agnix](https://github.com/avifenesh/agnix)** is a standalone open-source project that provides the validation engine. This plugin integrates it into your workflow.
+**[agnix](https://github.com/agent-sh/agnix)** is a standalone open-source project that provides the validation engine. This plugin integrates it into your workflow.
 
 **The problem it solves:**
 
@@ -255,7 +255,7 @@ agnix outputs SARIF format for GitHub Code Scanning. Add it to your workflow:
 
 **Agent:** agnix-agent (sonnet model)
 
-**External tool:** Requires [agnix CLI](https://github.com/avifenesh/agnix)
+**External tool:** Requires [agnix CLI](https://github.com/agent-sh/agnix)
 
 ```bash
 npm install -g agnix         # Install via npm
@@ -850,7 +850,7 @@ Every command works standalone. [`/deslop`](#deslop) cleans code without needing
 ### Claude Code (Recommended way)
 
 ```bash
-/plugin marketplace add avifenesh/agentsys
+/plugin marketplace add agent-sh/agentsys
 /plugin install next-task@agentsys
 /plugin install ship@agentsys
 ```
@@ -890,7 +890,7 @@ agentsys --development              # Dev mode (bypasses marketplace)
 - ast-grep (`sg`) installed
 
 **For /agnix:**
-- [agnix CLI](https://github.com/avifenesh/agnix) installed (`cargo install agnix-cli` or `brew install agnix`)
+- [agnix CLI](https://github.com/agent-sh/agnix) installed (`cargo install agnix-cli` or `brew install agnix`)
 
 **Local diagnostics (optional):**
 ```bash
@@ -952,8 +952,8 @@ The system is built on research, not guesswork.
 
 ## Support
 
-- **Issues:** [github.com/avifenesh/agentsys/issues](https://github.com/avifenesh/agentsys/issues)
-- **Discussions:** [github.com/avifenesh/agentsys/discussions](https://github.com/avifenesh/agentsys/discussions)
+- **Issues:** [github.com/agent-sh/agentsys/issues](https://github.com/agent-sh/agentsys/issues)
+- **Discussions:** [github.com/agent-sh/agentsys/discussions](https://github.com/agent-sh/agentsys/discussions)
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@
 If you discover a security vulnerability:
 
 1. **Do not** open a public issue
-2. Use [GitHub Security Advisories](https://github.com/avifenesh/agentsys/security/advisories) to report privately
+2. Use [GitHub Security Advisories](https://github.com/agent-sh/agentsys/security/advisories) to report privately
 3. Include steps to reproduce and potential impact
 
 ## User Responsibility

--- a/__tests__/scaffold.test.js
+++ b/__tests__/scaffold.test.js
@@ -513,8 +513,8 @@ describe('template content', () => {
       email: '[email protected]',
       url: 'https://github.com/avifenesh'
     });
-    expect(pkg.homepage).toBe('https://github.com/avifenesh/agentsys#author-test');
-    expect(pkg.repository).toBe('https://github.com/avifenesh/agentsys');
+    expect(pkg.homepage).toBe('https://github.com/agent-sh/agentsys#author-test');
+    expect(pkg.repository).toBe('https://github.com/agent-sh/agentsys');
   });
 });
 

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -7,7 +7,7 @@ This directory contains adapters for using agentsys commands with different AI c
 ### Claude Code (Native)
 The primary target. Install via marketplace:
 ```bash
-claude plugin marketplace add avifenesh/agentsys
+claude plugin marketplace add agent-sh/agentsys
 # Install specific plugins (e.g., next-task, ship, enhance)
 claude plugin install next-task@agentsys
 claude plugin install ship@agentsys
@@ -22,7 +22,7 @@ OpenAI's Codex command-line interface.
 
 **Installation:**
 ```bash
-git clone https://github.com/avifenesh/agentsys.git
+git clone https://github.com/agent-sh/agentsys.git
 cd agentsys
 ./adapters/codex/install.sh
 ```
@@ -44,7 +44,7 @@ Open-source AI coding assistant.
 
 **Installation:**
 ```bash
-git clone https://github.com/avifenesh/agentsys.git
+git clone https://github.com/agent-sh/agentsys.git
 cd agentsys
 ./adapters/opencode/install.sh
 ```
@@ -131,7 +131,7 @@ Installers automatically handle these substitutions.
 ### Claude Code
 ```bash
 # Via marketplace (easiest)
-claude plugin marketplace add avifenesh/agentsys
+claude plugin marketplace add agent-sh/agentsys
 claude plugin install next-task@agentsys
 ```
 
@@ -237,7 +237,7 @@ gh auth login
 
 Found a bug or want to add support for another tool?
 
-1. Open an issue: https://github.com/avifenesh/agentsys/issues
+1. Open an issue: https://github.com/agent-sh/agentsys/issues
 2. Submit a PR with:
    - New adapter directory: `adapters/[tool-name]/`
    - Installation script: `install.sh`
@@ -251,7 +251,7 @@ Found a bug or want to add support for another tool?
 - [Claude Code Documentation](https://code.claude.com/docs)
 - [Codex CLI Documentation](https://developers.openai.com/codex/cli)
 - [OpenCode Documentation](https://opencode.ai/docs)
-- [agentsys Repository](https://github.com/avifenesh/agentsys)
+- [agentsys Repository](https://github.com/agent-sh/agentsys)
 
 ---
 

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -5,7 +5,7 @@ Professional-grade slash commands adapted for OpenAI's Codex CLI.
 ## Quick Install
 
 ```bash
-git clone https://github.com/avifenesh/agentsys.git
+git clone https://github.com/agent-sh/agentsys.git
 cd agentsys
 ./adapters/codex/install.sh
 ```
@@ -255,8 +255,8 @@ gh auth status
 
 ## Support
 
-- **Repository**: https://github.com/avifenesh/agentsys
-- **Issues**: https://github.com/avifenesh/agentsys/issues
+- **Repository**: https://github.com/agent-sh/agentsys
+- **Issues**: https://github.com/agent-sh/agentsys/issues
 - **Codex CLI Docs**: https://developers.openai.com/codex/cli
 
 ---

--- a/adapters/codex/install.sh
+++ b/adapters/codex/install.sh
@@ -227,8 +227,8 @@ cd /path/to/agentsys
 
 ## Support
 
-- Repository: https://github.com/avifenesh/agentsys
-- Issues: https://github.com/avifenesh/agentsys/issues
+- Repository: https://github.com/agent-sh/agentsys
+- Issues: https://github.com/agent-sh/agentsys/issues
 EOF
 
 echo "  [OK] Created README"

--- a/adapters/codex/skills/agnix/SKILL.md
+++ b/adapters/codex/skills/agnix/SKILL.md
@@ -133,5 +133,5 @@ No issues found in agent configurations.
 
 ## Links
 
-- [agnix GitHub](https://github.com/avifenesh/agnix)
-- [Rules Reference](https://github.com/avifenesh/agnix/blob/main/knowledge-base/VALIDATION-RULES.md)
+- [agnix GitHub](https://github.com/agent-sh/agnix)
+- [Rules Reference](https://github.com/agent-sh/agnix/blob/main/knowledge-base/VALIDATION-RULES.md)

--- a/adapters/opencode/README.md
+++ b/adapters/opencode/README.md
@@ -5,7 +5,7 @@ Professional-grade slash commands adapted for OpenCode.
 ## Quick Install
 
 ```bash
-git clone https://github.com/avifenesh/agentsys.git
+git clone https://github.com/agent-sh/agentsys.git
 cd agentsys
 ./adapters/opencode/install.sh
 ```
@@ -284,8 +284,8 @@ gh auth status
 
 ## Support
 
-- **Repository**: https://github.com/avifenesh/agentsys
-- **Issues**: https://github.com/avifenesh/agentsys/issues
+- **Repository**: https://github.com/agent-sh/agentsys
+- **Issues**: https://github.com/agent-sh/agentsys/issues
 - **OpenCode Docs**: https://opencode.ai/docs
 
 ---

--- a/adapters/opencode/commands/agnix.md
+++ b/adapters/opencode/commands/agnix.md
@@ -101,5 +101,5 @@ No issues found in agent configurations.
 
 ## Links
 
-- [agnix GitHub](https://github.com/avifenesh/agnix)
-- [Rules Reference](https://github.com/avifenesh/agnix/blob/main/knowledge-base/VALIDATION-RULES.md)
+- [agnix GitHub](https://github.com/agent-sh/agnix)
+- [Rules Reference](https://github.com/agent-sh/agnix/blob/main/knowledge-base/VALIDATION-RULES.md)

--- a/adapters/opencode/install.sh
+++ b/adapters/opencode/install.sh
@@ -234,8 +234,8 @@ cd /path/to/agentsys
 
 ## Support
 
-- Repository: https://github.com/avifenesh/agentsys
-- Issues: https://github.com/avifenesh/agentsys/issues
+- Repository: https://github.com/agent-sh/agentsys
+- Issues: https://github.com/agent-sh/agentsys/issues
 EOF
 
 echo "  [OK] Created README"

--- a/adapters/opencode/skills/agnix/SKILL.md
+++ b/adapters/opencode/skills/agnix/SKILL.md
@@ -129,10 +129,10 @@ Exit codes:
 
 This skill is standalone and can be invoked directly via `/agnix`.
 
-For CI integration, see the [GitHub Action](https://github.com/avifenesh/agnix#github-action).
+For CI integration, see the [GitHub Action](https://github.com/agent-sh/agnix#github-action).
 
 ## Links
 
-- [GitHub](https://github.com/avifenesh/agnix)
-- [Rules Reference](https://github.com/avifenesh/agnix/blob/main/knowledge-base/VALIDATION-RULES.md)
-- [Configuration](https://github.com/avifenesh/agnix/blob/main/docs/CONFIGURATION.md)
+- [GitHub](https://github.com/agent-sh/agnix)
+- [Rules Reference](https://github.com/agent-sh/agnix/blob/main/knowledge-base/VALIDATION-RULES.md)
+- [Configuration](https://github.com/agent-sh/agnix/blob/main/docs/CONFIGURATION.md)

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -198,7 +198,7 @@ function installForClaude() {
     console.log('[WARN]  Claude Code CLI not detected.');
     console.log('   Install it first: https://claude.ai/code\n');
     console.log('   Then run in Claude Code:');
-    console.log('   /plugin marketplace add avifenesh/agentsys');
+    console.log('   /plugin marketplace add agent-sh/agentsys');
     console.log('   /plugin install next-task@agentsys\n');
     return false;
   }
@@ -207,7 +207,7 @@ function installForClaude() {
     // Add GitHub marketplace
     console.log('Adding marketplace...');
     try {
-      execSync('claude plugin marketplace add avifenesh/agentsys', { stdio: 'pipe' });
+      execSync('claude plugin marketplace add agent-sh/agentsys', { stdio: 'pipe' });
     } catch {
       // May already exist
     }
@@ -249,7 +249,7 @@ function installForClaude() {
     return true;
   } catch (err) {
     console.log('[ERROR] Auto-install failed. Manual installation:');
-    console.log('   /plugin marketplace add avifenesh/agentsys');
+    console.log('   /plugin marketplace add agent-sh/agentsys');
     console.log('   /plugin install next-task@agentsys');
     return false;
   }
@@ -270,7 +270,7 @@ function installForClaudeDevelopment() {
   // Remove marketplace plugins first
   console.log('Removing marketplace plugins...');
   try {
-    execSync('claude plugin marketplace remove avifenesh/agentsys', { stdio: 'pipe' });
+    execSync('claude plugin marketplace remove agent-sh/agentsys', { stdio: 'pipe' });
     console.log('  [OK] Removed marketplace');
   } catch {
     // May not exist
@@ -614,7 +614,7 @@ Install:  npm install -g agentsys && agentsys
 Update:   npm update -g agentsys && agentsys
 Remove:   npm uninstall -g agentsys && agentsys --remove
 
-Docs: https://github.com/avifenesh/agentsys
+Docs: https://github.com/agent-sh/agentsys
 `);
 }
 
@@ -684,7 +684,7 @@ async function main() {
     if (selected.length === 0) {
       console.log('\nNo platforms selected. Exiting.');
       console.log('\nFor Claude Code, you can also install directly:');
-      console.log('  /plugin marketplace add avifenesh/agentsys');
+      console.log('  /plugin marketplace add agent-sh/agentsys');
       process.exit(0);
     }
   }
@@ -739,7 +739,7 @@ async function main() {
   }
   console.log('\nTo update:  npm update -g agentsys');
   console.log('To remove:  npm uninstall -g agentsys && agentsys --remove');
-  console.log('\nDocs: https://github.com/avifenesh/agentsys');
+  console.log('\nDocs: https://github.com/agent-sh/agentsys');
 }
 
 // Export for testing when required as module

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -146,7 +146,7 @@ The package provides these capabilities through commands, agents, and skills:
 
 ```bash
 # Via marketplace (recommended)
-/plugin marketplace add avifenesh/agentsys
+/plugin marketplace add agent-sh/agentsys
 /plugin install next-task@agentsys
 
 # Via CLI installer

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -48,7 +48,7 @@ For OpenCode and Codex CLI, the installer adapts the platform argument handling 
 
 ```bash
 # Add the marketplace
-/plugin marketplace add avifenesh/agentsys
+/plugin marketplace add agent-sh/agentsys
 
 # Install plugins
 /plugin install next-task@agentsys

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -22,7 +22,7 @@ One codebase works across three platforms—Claude Code, OpenCode, and Codex CLI
 Add the marketplace and install plugins directly in Claude Code:
 
 ```bash
-/plugin marketplace add avifenesh/agentsys
+/plugin marketplace add agent-sh/agentsys
 /plugin install next-task@agentsys
 /plugin install ship@agentsys
 /plugin install deslop@agentsys
@@ -132,7 +132,7 @@ agentsys --tool claude
 For testing or development, load plugins directly:
 
 ```bash
-git clone https://github.com/avifenesh/agentsys.git
+git clone https://github.com/agent-sh/agentsys.git
 claude --plugin-dir ./agentsys/plugins/next-task
 ```
 
@@ -313,7 +313,7 @@ gh auth status
 
 Try adding the full GitHub URL:
 ```bash
-/plugin marketplace add https://github.com/avifenesh/agentsys.git
+/plugin marketplace add https://github.com/agent-sh/agentsys.git
 ```
 
 ### "GitHub CLI not found"
@@ -349,11 +349,11 @@ gh auth login
 
 ## Getting Help
 
-- **Issues:** https://github.com/avifenesh/agentsys/issues
-- **Discussions:** https://github.com/avifenesh/agentsys/discussions
+- **Issues:** https://github.com/agent-sh/agentsys/issues
+- **Discussions:** https://github.com/agent-sh/agentsys/discussions
 
 ```bash
-gh issue create --repo avifenesh/agentsys \
+gh issue create --repo agent-sh/agentsys \
   --title "Installation: [description]" \
   --body "Environment: [Claude Code/OpenCode/Codex], OS: [...]"
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,6 +120,6 @@ npm run verify   # Tool availability + versions
 
 ## Getting Help
 
-- **Issues:** [github.com/avifenesh/agentsys/issues](https://github.com/avifenesh/agentsys/issues)
-- **Discussions:** [github.com/avifenesh/agentsys/discussions](https://github.com/avifenesh/agentsys/discussions)
+- **Issues:** [github.com/agent-sh/agentsys/issues](https://github.com/agent-sh/agentsys/issues)
+- **Discussions:** [github.com/agent-sh/agentsys/discussions](https://github.com/agent-sh/agentsys/discussions)
 - **Main README:** [../README.md](../README.md)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -20,7 +20,7 @@ Follow [INSTALLATION.md](./INSTALLATION.md). For local testing:
 
 ```bash
 # Clone this repository
-git clone https://github.com/avifenesh/agentsys.git
+git clone https://github.com/agent-sh/agentsys.git
 cd agentsys
 
 # Install into Claude Code
@@ -314,7 +314,7 @@ If you find bugs during manual testing:
 2. Report on GitHub:
 
 ```bash
-gh issue create --repo avifenesh/agentsys \
+gh issue create --repo agent-sh/agentsys \
   --title "Bug: Command X failed" \
   --body "Detailed description with steps to reproduce"
 ```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -605,5 +605,5 @@ Every finding includes:
 ## Next Steps
 
 - **Start with**: `/deslop report` - safest command, immediate value
-- **For issues**: https://github.com/avifenesh/agentsys/issues
+- **For issues**: https://github.com/agent-sh/agentsys/issues
 - **Contributing**: See [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/lib/package.json
+++ b/lib/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/avifenesh/agentsys.git",
+    "url": "git+https://github.com/agent-sh/agentsys.git",
     "directory": "lib"
   },
   "files": [

--- a/lib/schemas/README.md
+++ b/lib/schemas/README.md
@@ -132,8 +132,8 @@ Validates `plugin.json` files with the following rules:
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": ["workflow", "automation", "productivity"],
   "minClaudeVersion": "1.0.0"

--- a/meta/skills/maintain-cross-platform/SKILL.md
+++ b/meta/skills/maintain-cross-platform/SKILL.md
@@ -491,7 +491,7 @@ If pushing version tag (v*):
 ### Key Functions
 
 **installForClaude()** - Line 116
-- Adds marketplace: `claude plugin marketplace add avifenesh/agentsys`
+- Adds marketplace: `claude plugin marketplace add agent-sh/agentsys`
 - Installs 9 plugins: `claude plugin install {plugin}@agentsys`
 - Commands: /next-task, /ship, /deslop, /audit-project, /drift-detect, /enhance, /perf, /sync-docs, /repo-map
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/avifenesh/agentsys.git"
+    "url": "git+https://github.com/agent-sh/agentsys.git"
   },
   "keywords": [
     "ai",
@@ -74,9 +74,9 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/avifenesh/agentsys/issues"
+    "url": "https://github.com/agent-sh/agentsys/issues"
   },
-  "homepage": "https://github.com/avifenesh/agentsys#readme",
+  "homepage": "https://github.com/agent-sh/agentsys#readme",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/plugins/agnix/.claude-plugin/plugin.json
+++ b/plugins/agnix/.claude-plugin/plugin.json
@@ -7,8 +7,8 @@
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agnix",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agnix",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": [
     "linting",

--- a/plugins/agnix/commands/agnix.md
+++ b/plugins/agnix/commands/agnix.md
@@ -135,5 +135,5 @@ No issues found in agent configurations.
 
 ## Links
 
-- [agnix GitHub](https://github.com/avifenesh/agnix)
-- [Rules Reference](https://github.com/avifenesh/agnix/blob/main/knowledge-base/VALIDATION-RULES.md)
+- [agnix GitHub](https://github.com/agent-sh/agnix)
+- [Rules Reference](https://github.com/agent-sh/agnix/blob/main/knowledge-base/VALIDATION-RULES.md)

--- a/plugins/agnix/skills/agnix/SKILL.md
+++ b/plugins/agnix/skills/agnix/SKILL.md
@@ -129,10 +129,10 @@ Exit codes:
 
 This skill is standalone and can be invoked directly via `/agnix`.
 
-For CI integration, see the [GitHub Action](https://github.com/avifenesh/agnix#github-action).
+For CI integration, see the [GitHub Action](https://github.com/agent-sh/agnix#github-action).
 
 ## Links
 
-- [GitHub](https://github.com/avifenesh/agnix)
-- [Rules Reference](https://github.com/avifenesh/agnix/blob/main/knowledge-base/VALIDATION-RULES.md)
-- [Configuration](https://github.com/avifenesh/agnix/blob/main/docs/CONFIGURATION.md)
+- [GitHub](https://github.com/agent-sh/agnix)
+- [Rules Reference](https://github.com/agent-sh/agnix/blob/main/knowledge-base/VALIDATION-RULES.md)
+- [Configuration](https://github.com/agent-sh/agnix/blob/main/docs/CONFIGURATION.md)

--- a/plugins/audit-project/.claude-plugin/plugin.json
+++ b/plugins/audit-project/.claude-plugin/plugin.json
@@ -7,8 +7,8 @@
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys#audit-project",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys#audit-project",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": [
     "code-review",

--- a/plugins/audit-project/lib/schemas/README.md
+++ b/plugins/audit-project/lib/schemas/README.md
@@ -132,8 +132,8 @@ Validates `plugin.json` files with the following rules:
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": ["workflow", "automation", "productivity"],
   "minClaudeVersion": "1.0.0"

--- a/plugins/consult/.claude-plugin/plugin.json
+++ b/plugins/consult/.claude-plugin/plugin.json
@@ -7,8 +7,8 @@
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys#consult",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys#consult",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": [
     "consultation",

--- a/plugins/debate/.claude-plugin/plugin.json
+++ b/plugins/debate/.claude-plugin/plugin.json
@@ -7,8 +7,8 @@
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys#debate",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys#debate",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": [
     "debate",

--- a/plugins/debate/lib/schemas/README.md
+++ b/plugins/debate/lib/schemas/README.md
@@ -132,8 +132,8 @@ Validates `plugin.json` files with the following rules:
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": ["workflow", "automation", "productivity"],
   "minClaudeVersion": "1.0.0"

--- a/plugins/deslop/.claude-plugin/plugin.json
+++ b/plugins/deslop/.claude-plugin/plugin.json
@@ -7,8 +7,8 @@
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys#deslop",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys#deslop",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": [
     "code-quality",

--- a/plugins/deslop/lib/schemas/README.md
+++ b/plugins/deslop/lib/schemas/README.md
@@ -132,8 +132,8 @@ Validates `plugin.json` files with the following rules:
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": ["workflow", "automation", "productivity"],
   "minClaudeVersion": "1.0.0"

--- a/plugins/drift-detect/.claude-plugin/plugin.json
+++ b/plugins/drift-detect/.claude-plugin/plugin.json
@@ -7,8 +7,8 @@
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys#drift-detect",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys#drift-detect",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": [
     "planning",

--- a/plugins/drift-detect/lib/schemas/README.md
+++ b/plugins/drift-detect/lib/schemas/README.md
@@ -132,8 +132,8 @@ Validates `plugin.json` files with the following rules:
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": ["workflow", "automation", "productivity"],
   "minClaudeVersion": "1.0.0"

--- a/plugins/enhance/.claude-plugin/plugin.json
+++ b/plugins/enhance/.claude-plugin/plugin.json
@@ -7,8 +7,8 @@
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys#enhance",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys#enhance",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": [
     "plugin-analyzer",

--- a/plugins/enhance/lib/schemas/README.md
+++ b/plugins/enhance/lib/schemas/README.md
@@ -132,8 +132,8 @@ Validates `plugin.json` files with the following rules:
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": ["workflow", "automation", "productivity"],
   "minClaudeVersion": "1.0.0"

--- a/plugins/learn/.claude-plugin/plugin.json
+++ b/plugins/learn/.claude-plugin/plugin.json
@@ -7,8 +7,8 @@
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys#learn",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys#learn",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": [
     "learning",

--- a/plugins/learn/lib/schemas/README.md
+++ b/plugins/learn/lib/schemas/README.md
@@ -132,8 +132,8 @@ Validates `plugin.json` files with the following rules:
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": ["workflow", "automation", "productivity"],
   "minClaudeVersion": "1.0.0"

--- a/plugins/next-task/.claude-plugin/plugin.json
+++ b/plugins/next-task/.claude-plugin/plugin.json
@@ -7,8 +7,8 @@
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys#next-task",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys#next-task",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": [
     "task-management",

--- a/plugins/next-task/lib/schemas/README.md
+++ b/plugins/next-task/lib/schemas/README.md
@@ -132,8 +132,8 @@ Validates `plugin.json` files with the following rules:
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": ["workflow", "automation", "productivity"],
   "minClaudeVersion": "1.0.0"

--- a/plugins/perf/.claude-plugin/plugin.json
+++ b/plugins/perf/.claude-plugin/plugin.json
@@ -7,8 +7,8 @@
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys#perf",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys#perf",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": [
     "performance",

--- a/plugins/perf/lib/schemas/README.md
+++ b/plugins/perf/lib/schemas/README.md
@@ -132,8 +132,8 @@ Validates `plugin.json` files with the following rules:
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": ["workflow", "automation", "productivity"],
   "minClaudeVersion": "1.0.0"

--- a/plugins/repo-map/.claude-plugin/plugin.json
+++ b/plugins/repo-map/.claude-plugin/plugin.json
@@ -7,8 +7,8 @@
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys#repo-map",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys#repo-map",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": [
     "repo-map",

--- a/plugins/repo-map/lib/schemas/README.md
+++ b/plugins/repo-map/lib/schemas/README.md
@@ -132,8 +132,8 @@ Validates `plugin.json` files with the following rules:
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": ["workflow", "automation", "productivity"],
   "minClaudeVersion": "1.0.0"

--- a/plugins/ship/.claude-plugin/plugin.json
+++ b/plugins/ship/.claude-plugin/plugin.json
@@ -7,8 +7,8 @@
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys#ship",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys#ship",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": [
     "ci-cd",

--- a/plugins/ship/lib/schemas/README.md
+++ b/plugins/ship/lib/schemas/README.md
@@ -132,8 +132,8 @@ Validates `plugin.json` files with the following rules:
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": ["workflow", "automation", "productivity"],
   "minClaudeVersion": "1.0.0"

--- a/plugins/sync-docs/.claude-plugin/plugin.json
+++ b/plugins/sync-docs/.claude-plugin/plugin.json
@@ -7,8 +7,8 @@
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys#sync-docs",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys#sync-docs",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": [
     "documentation",

--- a/plugins/sync-docs/lib/schemas/README.md
+++ b/plugins/sync-docs/lib/schemas/README.md
@@ -132,8 +132,8 @@ Validates `plugin.json` files with the following rules:
     "email": "[email protected]",
     "url": "https://github.com/avifenesh"
   },
-  "homepage": "https://github.com/avifenesh/agentsys",
-  "repository": "https://github.com/avifenesh/agentsys",
+  "homepage": "https://github.com/agent-sh/agentsys",
+  "repository": "https://github.com/agent-sh/agentsys",
   "license": "MIT",
   "keywords": ["workflow", "automation", "productivity"],
   "minClaudeVersion": "1.0.0"

--- a/scripts/dev-install.js
+++ b/scripts/dev-install.js
@@ -213,7 +213,7 @@ function installClaude() {
 
   // Remove marketplace plugins first
   try {
-    execSync('claude plugin marketplace remove avifenesh/agentsys', { stdio: 'pipe' });
+    execSync('claude plugin marketplace remove agent-sh/agentsys', { stdio: 'pipe' });
     log('  Removed marketplace');
   } catch {
     // May not exist

--- a/scripts/scaffold.js
+++ b/scripts/scaffold.js
@@ -112,8 +112,8 @@ function scaffoldPlugin(name, projectRoot) {
       email: '[email protected]',
       url: 'https://github.com/avifenesh'
     },
-    homepage: `https://github.com/avifenesh/agentsys#${name}`,
-    repository: 'https://github.com/avifenesh/agentsys',
+    homepage: `https://github.com/agent-sh/agentsys#${name}`,
+    repository: 'https://github.com/agent-sh/agentsys',
     license: 'MIT',
     keywords: [name]
   };

--- a/site/content.json
+++ b/site/content.json
@@ -2,8 +2,8 @@
   "meta": {
     "title": "agentsys",
     "description": "A modular runtime and orchestration system for AI agents. 12 plugins, 41 agents, 27 skills — structured pipelines for Claude Code, OpenCode, and Codex CLI.",
-    "url": "https://avifenesh.github.io/agentsys",
-    "repo": "https://github.com/avifenesh/agentsys",
+    "url": "https://agent-sh.github.io/agentsys",
+    "repo": "https://github.com/agent-sh/agentsys",
     "npm": "https://www.npmjs.com/package/agentsys",
     "version": "5.1.0",
     "author": "Avi Fenesh",
@@ -18,7 +18,7 @@
     },
     "cta_secondary": {
       "text": "View on GitHub",
-      "url": "https://github.com/avifenesh/agentsys"
+      "url": "https://github.com/agent-sh/agentsys"
     }
   },
   "stats": [
@@ -208,7 +208,7 @@
         "Install the plugins you need"
       ],
       "commands": [
-        "/plugin marketplace add avifenesh/agentsys",
+        "/plugin marketplace add agent-sh/agentsys",
         "/plugin install next-task@agentsys",
         "/plugin install ship@agentsys"
       ]
@@ -445,9 +445,9 @@
   "footer": {
     "license": "MIT",
     "author": "Avi Fenesh",
-    "github_url": "https://github.com/avifenesh/agentsys",
+    "github_url": "https://github.com/agent-sh/agentsys",
     "npm_url": "https://www.npmjs.com/package/agentsys",
-    "issues_url": "https://github.com/avifenesh/agentsys/issues",
-    "discussions_url": "https://github.com/avifenesh/agentsys/discussions"
+    "issues_url": "https://github.com/agent-sh/agentsys/issues",
+    "discussions_url": "https://github.com/agent-sh/agentsys/discussions"
   }
 }

--- a/site/index.html
+++ b/site/index.html
@@ -10,15 +10,15 @@
   <!-- Open Graph -->
   <meta property="og:title" content="AgentSys">
   <meta property="og:description" content="A modular runtime and orchestration system for AI agents. 12 plugins, 41 agents, 27 skills.">
-  <meta property="og:image" content="https://avifenesh.github.io/agentsys/assets/logo.png">
-  <meta property="og:url" content="https://avifenesh.github.io/agentsys/">
+  <meta property="og:image" content="https://agent-sh.github.io/agentsys/assets/logo.png">
+  <meta property="og:url" content="https://agent-sh.github.io/agentsys/">
   <meta property="og:type" content="website">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="AgentSys">
   <meta name="twitter:description" content="AI workflow automation. 11 plugins, 40 agents, 26 skills.">
-  <meta name="twitter:image" content="https://avifenesh.github.io/agentsys/assets/logo.png">
+  <meta name="twitter:image" content="https://agent-sh.github.io/agentsys/assets/logo.png">
 
   <!-- Content Security Policy -->
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'">
@@ -76,7 +76,7 @@
         <a href="#install" class="nav__link" data-section="install">Install</a>
       </div>
 
-      <a href="https://github.com/avifenesh/agentsys" class="nav__cta" target="_blank" rel="noopener noreferrer" aria-label="View AgentSys on GitHub">
+      <a href="https://github.com/agent-sh/agentsys" class="nav__cta" target="_blank" rel="noopener noreferrer" aria-label="View AgentSys on GitHub">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
         <span>GitHub</span>
       </a>
@@ -98,7 +98,7 @@
       <a href="#how-it-works" class="mobile-menu__link">How It Works</a>
       <a href="#agents-skills" class="mobile-menu__link">Agents</a>
       <a href="#install" class="mobile-menu__link">Install</a>
-      <a href="https://github.com/avifenesh/agentsys" class="mobile-menu__link" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://github.com/agent-sh/agentsys" class="mobile-menu__link" target="_blank" rel="noopener noreferrer">GitHub</a>
     </div>
   </div>
 
@@ -119,7 +119,7 @@
           </p>
           <div class="hero__ctas anim-fade-up" data-delay="500">
             <a href="#install" class="btn btn--primary">Get Started</a>
-            <a href="https://github.com/avifenesh/agentsys" class="btn btn--ghost" target="_blank" rel="noopener noreferrer">View on GitHub</a>
+            <a href="https://github.com/agent-sh/agentsys" class="btn btn--ghost" target="_blank" rel="noopener noreferrer">View on GitHub</a>
           </div>
         </div>
 
@@ -634,12 +634,12 @@
           <div class="tabs__panel tabs__panel--active" role="tabpanel" id="install-panel-0" aria-labelledby="install-tab-0">
             <p class="install__label">Recommended</p>
             <div class="code-block">
-              <button class="code-block__copy" aria-label="Copy code to clipboard" data-code="/plugin marketplace add avifenesh/agentsys
+              <button class="code-block__copy" aria-label="Copy code to clipboard" data-code="/plugin marketplace add agent-sh/agentsys
 /plugin install next-task@agentsys
 /plugin install ship@agentsys">
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"/><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"/></svg>
               </button>
-              <pre><code><span class="code-prompt">$</span> /plugin marketplace add avifenesh/agentsys
+              <pre><code><span class="code-prompt">$</span> /plugin marketplace add agent-sh/agentsys
 <span class="code-prompt">$</span> /plugin install next-task@agentsys
 <span class="code-prompt">$</span> /plugin install ship@agentsys</code></pre>
             </div>
@@ -658,12 +658,12 @@
           <div class="tabs__panel" role="tabpanel" id="install-panel-2" aria-labelledby="install-tab-2" hidden>
             <p class="install__label">Clone and install from source</p>
             <div class="code-block">
-              <button class="code-block__copy" aria-label="Copy code to clipboard" data-code="git clone https://github.com/avifenesh/agentsys.git
+              <button class="code-block__copy" aria-label="Copy code to clipboard" data-code="git clone https://github.com/agent-sh/agentsys.git
 cd agentsys
 npm install">
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"/><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"/></svg>
               </button>
-              <pre><code><span class="code-prompt">$</span> git clone https://github.com/avifenesh/agentsys.git
+              <pre><code><span class="code-prompt">$</span> git clone https://github.com/agent-sh/agentsys.git
 <span class="code-prompt">$</span> cd agentsys
 <span class="code-prompt">$</span> npm install</code></pre>
             </div>
@@ -683,10 +683,10 @@ npm install">
         <span class="footer__license">MIT License</span>
       </div>
       <div class="footer__links">
-        <a href="https://github.com/avifenesh/agentsys" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://github.com/agent-sh/agentsys" target="_blank" rel="noopener noreferrer">GitHub</a>
         <a href="https://www.npmjs.com/package/agentsys" target="_blank" rel="noopener noreferrer">npm</a>
-        <a href="https://github.com/avifenesh/agentsys/issues" target="_blank" rel="noopener noreferrer">Issues</a>
-        <a href="https://github.com/avifenesh/agentsys/discussions" target="_blank" rel="noopener noreferrer">Discussions</a>
+        <a href="https://github.com/agent-sh/agentsys/issues" target="_blank" rel="noopener noreferrer">Issues</a>
+        <a href="https://github.com/agent-sh/agentsys/discussions" target="_blank" rel="noopener noreferrer">Discussions</a>
       </div>
       <div class="footer__meta">
         <span class="footer__version" id="site-version">v5.0.0</span>

--- a/site/ux-spec.md
+++ b/site/ux-spec.md
@@ -11,7 +11,7 @@ Last updated: 2026-02-08
 
 The entire site is one HTML file with section anchors. All navigation is smooth-scroll to sections within the page. This keeps the build zero-dependency (no static site generator, no framework) and makes the site feel fast and cohesive.
 
-**URL:** `https://avifenesh.github.io/agentsys/`
+**URL:** `https://agent-sh.github.io/agentsys/`
 
 **File structure:**
 ```
@@ -399,7 +399,7 @@ Tab styling matches Commands section tab bar but smaller scale:
 
 **Claude Code tab:**
 ```bash
-/plugin marketplace add avifenesh/agentsys
+/plugin marketplace add agent-sh/agentsys
 /plugin install next-task@agentsys
 /plugin install ship@agentsys
 ```
@@ -413,7 +413,7 @@ Below the code block: "Interactive installer for Claude Code, OpenCode, and Code
 **Manual tab:**
 ```bash
 # Clone and install
-git clone https://github.com/avifenesh/agentsys.git
+git clone https://github.com/agent-sh/agentsys.git
 cd agentsys
 npm install
 ```
@@ -553,7 +553,7 @@ Add a website badge to the existing badge row in `README.md`, positioned after t
 
 **New line 8 (insert after):**
 ```markdown
-[![Website](https://img.shields.io/badge/Website-AgentSys-blue?style=flat&logo=github)](https://avifenesh.github.io/agentsys/)
+[![Website](https://img.shields.io/badge/Website-AgentSys-blue?style=flat&logo=github)](https://agent-sh.github.io/agentsys/)
 ```
 
 This uses:
@@ -657,15 +657,15 @@ This disables:
 <!-- Open Graph -->
 <meta property="og:title" content="AgentSys">
 <meta property="og:description" content="AI workflow automation. 11 plugins, 40 agents, 26 skills. Task to merged PR.">
-<meta property="og:image" content="https://avifenesh.github.io/agentsys/assets/og-image.png">
-<meta property="og:url" content="https://avifenesh.github.io/agentsys/">
+<meta property="og:image" content="https://agent-sh.github.io/agentsys/assets/og-image.png">
+<meta property="og:url" content="https://agent-sh.github.io/agentsys/">
 <meta property="og:type" content="website">
 
 <!-- Twitter Card -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AgentSys">
 <meta name="twitter:description" content="AI workflow automation. 11 plugins, 40 agents, 26 skills.">
-<meta name="twitter:image" content="https://avifenesh.github.io/agentsys/assets/og-image.png">
+<meta name="twitter:image" content="https://agent-sh.github.io/agentsys/assets/og-image.png">
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Updates all GitHub repo links from `avifenesh/agentsys` → `agent-sh/agentsys`
- Updates all `avifenesh/agnix` → `agent-sh/agnix` references
- Updates `avifenesh.github.io` → `agent-sh.github.io` Pages URLs
- 58 files changed across README, docs, plugins, adapters, scripts, site
- Preserves personal author URLs (`github.com/avifenesh`)

## Test plan
- [ ] Badges render correctly with new org URLs
- [ ] Install instructions point to correct repo
- [ ] Site links resolve to agent-sh.github.io