### PR TITLE
feat: auto-add issues/PRs to org project board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,18 +1,20 @@
+# Auto-add new issues and PRs to the agent-sh org project board.
+# Requires PROJECT_TOKEN org secret (PAT with `project` scope).
 name: Add to project
+
 on:
   issues:
     types: [opened, transferred]
-  pull_request:
+  pull_request_target:
     types: [opened]
+
 permissions: {}
+
 jobs:
   add:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
-    permissions:
-      contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@9bfe8798cd4bc4824deec9771ac4dfd86e5adf48
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/agent-sh/projects/1
           github-token: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
Adds workflow to auto-add new issues and PRs to [agent-sh Roadmap](https://github.com/orgs/agent-sh/projects/1).