### PR TITLE
fix: normalize string entries in loadComponents to prevent padEnd crash

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -786,10 +786,13 @@ function loadComponents(pluginDir) {
   if (fs.existsSync(componentsPath)) {
     try {
       const data = JSON.parse(fs.readFileSync(componentsPath, 'utf8'));
+      const normalize = (arr) => (arr || []).map(item =>
+        typeof item === 'string' ? { name: item } : item
+      );
       return {
-        agents: data.agents || [],
-        skills: data.skills || [],
-        commands: data.commands || []
+        agents: normalize(data.agents),
+        skills: normalize(data.skills),
+        commands: normalize(data.commands)
       };
     } catch {
       // Fall through to filesystem scan


### PR DESCRIPTION
## Summary

- `agentsys list --all`, `--agents`, `--skills`, and `--commands` crash with `Cannot read properties of undefined (reading 'padEnd')` because `loadComponents()` returns raw string entries from `components.json` while the display code expects objects with a `.name` property
- Normalizes string entries to `{name}` objects in `loadComponents()` so both string and object entries are handled correctly
- Minimal fix in one place rather than defensive checks scattered across display code

## Test plan

- [x] `agentsys list --agents` lists all 32 agents without error
- [x] `agentsys list --skills` lists all 30 skills without error
- [x] `agentsys list --commands` lists all 19 commands without error
- [x] `agentsys list --all` shows everything without error
- [x] All 3659 existing tests pass (88 suites)