### PR TITLE
chore: release v5.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "agentsys",
   "description": "14 specialized plugins for AI workflow automation - task orchestration, PR workflow, slop detection, code review, drift detection, enhancement analysis, documentation sync, repo mapping, perf investigations, topic research, agent config linting, cross-tool AI consultation, and structured AI debate",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "owner": {
     "name": "Avi Fenesh",
     "url": "https://github.com/avifenesh"
@@ -24,7 +24,10 @@
   "plugins": [
     {
       "name": "next-task",
-      "source": {"source": "url", "url": "https://github.com/agent-sh/next-task.git"},
+      "source": {
+        "source": "url",
+        "url": "https://github.com/agent-sh/next-task.git"
+      },
       "description": "Master workflow orchestrator: autonomous workflow with model optimization (opus/sonnet/haiku), two-file state management, workflow enforcement gates, 14 specialist agents",
       "version": "1.0.0",
       "category": "productivity",
@@ -32,7 +35,10 @@
     },
     {
       "name": "ship",
-      "source": {"source": "url", "url": "https://github.com/agent-sh/ship.git"},
+      "source": {
+        "source": "url",
+        "url": "https://github.com/agent-sh/ship.git"
+      },
       "description": "Complete PR workflow: commit to production, skips review when called from next-task, removes task from registry on cleanup, automatic rollback",
       "version": "1.0.0",
       "category": "deployment",
@@ -40,7 +46,10 @@
     },
     {
       "name": "deslop",
-      "source": {"source": "url", "url": "https://github.com/agent-sh/deslop.git"},
+      "source": {
+        "source": "url",
+        "url": "https://github.com/agent-sh/deslop.git"
+      },
       "description": "3-phase AI slop detection: regex patterns (HIGH), multi-pass analyzers (MEDIUM), CLI tools (LOW)",
       "version": "1.0.0",
       "category": "development",
@@ -48,7 +57,10 @@
     },
     {
       "name": "audit-project",
-      "source": {"source": "url", "url": "https://github.com/agent-sh/audit-project.git"},
+      "source": {
+        "source": "url",
+        "url": "https://github.com/agent-sh/audit-project.git"
+      },
       "description": "Multi-agent iterative code review until zero issues remain",
       "version": "1.0.0",
       "category": "development",
@@ -56,7 +68,10 @@
     },
     {
       "name": "drift-detect",
-      "source": {"source": "url", "url": "https://github.com/agent-sh/drift-detect.git"},
+      "source": {
+        "source": "url",
+        "url": "https://github.com/agent-sh/drift-detect.git"
+      },
       "description": "Deep repository analysis to realign project plans with code reality - detects drift, gaps, and creates prioritized reconstruction plans",
       "version": "1.0.0",
       "category": "productivity",
@@ -64,7 +79,10 @@
     },
     {
       "name": "enhance",
-      "source": {"source": "url", "url": "https://github.com/agent-sh/enhance.git"},
+      "source": {
+        "source": "url",
+        "url": "https://github.com/agent-sh/enhance.git"
+      },
       "description": "Master enhancement orchestrator: parallel analyzer execution for plugins, agents, docs, CLAUDE.md, and prompts with unified reporting",
       "version": "1.0.0",
       "category": "development",
@@ -72,7 +90,10 @@
     },
     {
       "name": "sync-docs",
-      "source": {"source": "url", "url": "https://github.com/agent-sh/sync-docs.git"},
+      "source": {
+        "source": "url",
+        "url": "https://github.com/agent-sh/sync-docs.git"
+      },
       "description": "Standalone documentation sync: find outdated refs, update CHANGELOG, flag stale examples based on code changes",
       "version": "1.0.0",
       "category": "development",
@@ -80,7 +101,10 @@
     },
     {
       "name": "repo-map",
-      "source": {"source": "url", "url": "https://github.com/agent-sh/repo-map.git"},
+      "source": {
+        "source": "url",
+        "url": "https://github.com/agent-sh/repo-map.git"
+      },
       "description": "AST-based repository map generation using ast-grep with incremental updates for faster drift analysis",
       "version": "1.0.0",
       "category": "development",
@@ -88,7 +112,10 @@
     },
     {
       "name": "perf",
-      "source": {"source": "url", "url": "https://github.com/agent-sh/perf.git"},
+      "source": {
+        "source": "url",
+        "url": "https://github.com/agent-sh/perf.git"
+      },
       "description": "Rigorous performance investigation workflow with baselines, profiling, hypotheses, and evidence-backed decisions",
       "version": "1.0.0",
       "category": "development",
@@ -96,7 +123,10 @@
     },
     {
       "name": "learn",
-      "source": {"source": "url", "url": "https://github.com/agent-sh/learn.git"},
+      "source": {
+        "source": "url",
+        "url": "https://github.com/agent-sh/learn.git"
+      },
       "description": "Research topics online and create comprehensive learning guides with RAG-optimized indexes",
       "version": "1.0.0",
       "category": "productivity",
@@ -104,7 +134,10 @@
     },
     {
       "name": "agnix",
-      "source": {"source": "url", "url": "https://github.com/agent-sh/agnix.git"},
+      "source": {
+        "source": "url",
+        "url": "https://github.com/agent-sh/agnix.git"
+      },
       "description": "Lint agent configuration files (SKILL.md, CLAUDE.md, hooks, MCP) against 155 rules across 10+ AI tools",
       "version": "1.0.0",
       "category": "development",
@@ -112,7 +145,10 @@
     },
     {
       "name": "consult",
-      "source": {"source": "url", "url": "https://github.com/agent-sh/consult.git"},
+      "source": {
+        "source": "url",
+        "url": "https://github.com/agent-sh/consult.git"
+      },
       "description": "Cross-tool AI consultation: get second opinions from Gemini CLI, Codex CLI, Claude Code, OpenCode, or Copilot CLI with model and thinking effort control",
       "version": "1.0.0",
       "category": "productivity",
@@ -120,7 +156,10 @@
     },
     {
       "name": "debate",
-      "source": {"source": "url", "url": "https://github.com/agent-sh/debate.git"},
+      "source": {
+        "source": "url",
+        "url": "https://github.com/agent-sh/debate.git"
+      },
       "description": "Structured multi-round debate between AI tools with proposer/challenger roles and verdict",
       "version": "1.0.0",
       "category": "productivity",
@@ -128,7 +167,10 @@
     },
     {
       "name": "web-ctl",
-      "source": {"source": "url", "url": "https://github.com/agent-sh/web-ctl.git"},
+      "source": {
+        "source": "url",
+        "url": "https://github.com/agent-sh/web-ctl.git"
+      },
       "description": "Browser automation and web testing toolkit for AI agents - headless browser control, persistent sessions, auth handoff, and prompt injection defense",
       "version": "1.0.0",
       "category": "automation",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Professional-grade slash commands for Claude Code with cross-platform support",
   "keywords": [
     "workflow",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.1.1] - 2026-03-01
+
 ### Added
 
 - **`/web-ctl` plugin** — New plugin for browser automation and web testing. Headless browser control via Playwright with persistent encrypted sessions, human-in-the-loop auth handoff (including CAPTCHA detection and checkpoint mode), anti-bot measures (webdriver spoofing, random delays), WSL detection with Windows Chrome fallback, and prompt injection defense via `[PAGE_CONTENT: ...]` delimiters. Includes `web-session` agent, `web-auth` and `web-browse` skills, and the `/web-ctl` command. Available at [agent-sh/web-ctl](https://github.com/agent-sh/web-ctl).

--- a/__tests__/cli-subcommands.test.js
+++ b/__tests__/cli-subcommands.test.js
@@ -20,7 +20,9 @@ const {
   parseInstallTarget,
   loadComponents,
   resolveComponent,
-  buildFilterFromComponent
+  buildFilterFromComponent,
+  resolvePluginSource,
+  parseGitHubSource
 } = require('../bin/cli.js');
 
 describe('CLI subcommand parsing', () => {
@@ -377,5 +379,54 @@ describe('loadMarketplace', () => {
       expect(p.source).toBeTruthy();
       expect(p.version).toBeTruthy();
     }
+  });
+});
+
+describe('resolvePluginSource', () => {
+  test('supports legacy string URL sources', () => {
+    expect(resolvePluginSource('https://github.com/agent-sh/ship.git')).toEqual({
+      type: 'remote',
+      value: 'https://github.com/agent-sh/ship.git'
+    });
+  });
+
+  test('supports structured URL source objects', () => {
+    expect(resolvePluginSource({
+      source: 'url',
+      url: 'https://github.com/agent-sh/ship.git'
+    })).toEqual({
+      type: 'remote',
+      value: 'https://github.com/agent-sh/ship.git'
+    });
+  });
+
+  test('classifies local path sources as local', () => {
+    expect(resolvePluginSource({
+      source: 'path',
+      path: './plugins/ship'
+    })).toEqual({
+      type: 'local',
+      value: './plugins/ship'
+    });
+  });
+});
+
+describe('parseGitHubSource', () => {
+  test('normalizes .git suffix in https URLs', () => {
+    expect(parseGitHubSource('https://github.com/agent-sh/ship.git', '1.0.0')).toEqual({
+      owner: 'agent-sh',
+      repo: 'ship',
+      ref: 'v1.0.0',
+      explicitRef: false
+    });
+  });
+
+  test('preserves explicit refs', () => {
+    expect(parseGitHubSource('https://github.com/agent-sh/ship.git#main', '1.0.0')).toEqual({
+      owner: 'agent-sh',
+      repo: 'ship',
+      ref: 'main',
+      explicitRef: true
+    });
   });
 });

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -231,6 +231,50 @@ function loadMarketplace() {
 }
 
 /**
+ * Normalize marketplace plugin source entries.
+ *
+ * Supported formats:
+ * - string URL/path (legacy)
+ * - object: { source: "url", url: "..." } (current)
+ * - object: { source: "path", path: "..." } (local/bundled)
+ *
+ * @param {string|Object} source
+ * @returns {{type: 'remote'|'local', value: string}|null}
+ */
+function resolvePluginSource(source) {
+  if (typeof source === 'string') {
+    const value = source.trim();
+    if (!value) return null;
+    if (value.startsWith('./') || value.startsWith('../')) {
+      return { type: 'local', value };
+    }
+    return { type: 'remote', value };
+  }
+
+  if (!source || typeof source !== 'object') return null;
+
+  const sourceType = typeof source.source === 'string' ? source.source.toLowerCase() : null;
+
+  if ((sourceType === 'path' || sourceType === 'local') && typeof source.path === 'string') {
+    return { type: 'local', value: source.path };
+  }
+
+  if (sourceType === 'url' && typeof source.url === 'string') {
+    return { type: 'remote', value: source.url };
+  }
+
+  // Backward/forward-compatible fallbacks
+  if (typeof source.path === 'string') {
+    return { type: 'local', value: source.path };
+  }
+  if (typeof source.url === 'string') {
+    return { type: 'remote', value: source.url };
+  }
+
+  return null;
+}
+
+/**
  * Resolve plugin dependencies transitively.
  *
  * Circular dependencies are expected and handled: the `visiting` Set tracks
@@ -300,37 +344,72 @@ async function fetchPlugin(name, source, version) {
     }
   }
 
+  const parsedSource = parseGitHubSource(source, version, name);
+  const owner = parsedSource.owner;
+  const repo = parsedSource.repo;
+
+  const refCandidates = parsedSource.explicitRef
+    ? [parsedSource.ref]
+    : [parsedSource.ref, version, 'main', 'master'];
+
+  let lastError = null;
+  for (const ref of [...new Set(refCandidates.filter(Boolean))]) {
+    const tarballUrl = `https://api.github.com/repos/${owner}/${repo}/tarball/${ref}`;
+
+    try {
+      console.log(`  Fetching ${name}@${version} from ${owner}/${repo} (${ref})...`);
+
+      // Clean and recreate
+      if (fs.existsSync(pluginDir)) {
+        fs.rmSync(pluginDir, { recursive: true, force: true });
+      }
+      fs.mkdirSync(pluginDir, { recursive: true });
+
+      // Download and extract tarball
+      await downloadAndExtractTarball(tarballUrl, pluginDir);
+
+      // Write version marker
+      fs.writeFileSync(versionFile, version);
+      return pluginDir;
+    } catch (err) {
+      lastError = err;
+      const isNotFound = /HTTP 404/.test(err.message);
+      if (isNotFound && !parsedSource.explicitRef) {
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  throw new Error(
+    `Unable to fetch ${name} from ${owner}/${repo}. Tried refs: ${[...new Set(refCandidates.filter(Boolean))].join(', ')}. Last error: ${lastError ? lastError.message : 'unknown error'}`
+  );
+}
+
+/**
+ * Parse GitHub source URL formats and normalize repo name.
+ *
+ * @param {string} source
+ * @param {string} version
+ * @param {string} [name]
+ * @returns {{owner: string, repo: string, ref: string, explicitRef: boolean}}
+ */
+function parseGitHubSource(source, version, name = 'plugin') {
   // Parse source formats:
   //   "https://github.com/owner/repo" or "https://github.com/owner/repo#ref"
   //   "github:owner/repo" or "github:owner/repo#ref"
-  let owner, repo, ref;
   const urlMatch = source.match(/github\.com\/([^/]+)\/([^/#]+)(?:#(.+))?/);
   const shortMatch = !urlMatch && source.match(/^github:([^/]+)\/([^#]+)(?:#(.+))?$/);
   const match = urlMatch || shortMatch;
   if (!match) {
     throw new Error(`Unsupported source format for ${name}: ${source}`);
   }
-  owner = match[1];
-  repo = match[2];
-  ref = match[3] || `v${version}`;
 
-  const tarballUrl = `https://api.github.com/repos/${owner}/${repo}/tarball/${ref}`;
-
-  console.log(`  Fetching ${name}@${version} from ${owner}/${repo}...`);
-
-  // Clean and recreate
-  if (fs.existsSync(pluginDir)) {
-    fs.rmSync(pluginDir, { recursive: true, force: true });
-  }
-  fs.mkdirSync(pluginDir, { recursive: true });
-
-  // Download and extract tarball
-  await downloadAndExtractTarball(tarballUrl, pluginDir);
-
-  // Write version marker
-  fs.writeFileSync(versionFile, version);
-
-  return pluginDir;
+  const owner = match[1];
+  const repo = match[2].replace(/\.git$/, '');
+  const explicitRef = Boolean(match[3]);
+  const ref = match[3] || `v${version}`;
+  return { owner, repo, ref, explicitRef };
 }
 
 /**
@@ -447,15 +526,17 @@ async function fetchExternalPlugins(pluginNames, marketplace) {
     const plugin = pluginMap[name];
     if (!plugin) continue;
 
-    // If source is local (starts with ./), plugin is bundled - just use PACKAGE_DIR
-    if (!plugin.source || plugin.source.startsWith('./') || plugin.source.startsWith('../')) {
+    const source = resolvePluginSource(plugin.source);
+
+    // Local/bundled plugin, no external fetch needed
+    if (!source || source.type === 'local') {
       // Bundled plugin, no fetch needed
       fetched.push(name);
       continue;
     }
 
     try {
-      await fetchPlugin(name, plugin.source, plugin.version);
+      await fetchPlugin(name, source.value, plugin.version);
       fetched.push(name);
     } catch (err) {
       failed.push(name);
@@ -469,6 +550,8 @@ async function fetchExternalPlugins(pluginNames, marketplace) {
       console.error(`\n  [WARN] Missing dependencies: ${missingDeps.join(', ')}`);
       console.error(`  Some plugins may not work correctly without their dependencies.`);
     }
+
+    throw new Error(`Failed to fetch ${failed.length} plugin(s): ${failed.join(', ')}`);
   }
 
   return fetched;
@@ -887,11 +970,15 @@ async function installPlugin(nameWithVersion, args) {
   // Fetch all
   for (const depName of toFetch) {
     const dep = pluginMap[depName];
-    if (!dep || !dep.source || dep.source.startsWith('./')) continue;
+    if (!dep) continue;
+
+    const source = resolvePluginSource(dep.source);
+    if (!source || source.type === 'local') continue;
+
     checkCoreCompat(dep);
     const ver = depName === name && requestedVersion ? requestedVersion : dep.version;
     try {
-      await fetchPlugin(depName, dep.source, ver);
+      await fetchPlugin(depName, source.value, ver);
     } catch (err) {
       console.error(`  [ERROR] Failed to fetch ${depName}: ${err.message}`);
     }
@@ -1799,8 +1886,6 @@ async function main() {
     if (entry) checkCoreCompat(entry);
   }
 
-  await fetchExternalPlugins(pluginNames, marketplace);
-
   // Only copy to ~/.agentsys if OpenCode or Codex selected (they need local files)
   const needsLocalInstall = selected.includes('opencode') || selected.includes('codex');
   let installDir = null;
@@ -1811,6 +1896,8 @@ async function main() {
     copyFromPackage(installDir);
     installDependencies(installDir);
   }
+
+  await fetchExternalPlugins(pluginNames, marketplace);
 
   // Install for each platform
   const failedPlatforms = [];
@@ -1885,5 +1972,7 @@ module.exports = {
   parseInstallTarget,
   loadComponents,
   resolveComponent,
-  buildFilterFromComponent
+  buildFilterFromComponent,
+  resolvePluginSource,
+  parseGitHubSource
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentsys",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentsys",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "MIT",
       "workspaces": [
         "lib"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "A modular runtime and orchestration system for AI agents - works with Claude Code, OpenCode, and Codex CLI",
   "main": "lib/platform/detect-platform.js",
   "type": "commonjs",

--- a/site/content.json
+++ b/site/content.json
@@ -5,7 +5,7 @@
     "url": "https://agent-sh.github.io/agentsys",
     "repo": "https://github.com/agent-sh/agentsys",
     "npm": "https://www.npmjs.com/package/agentsys",
-    "version": "5.1.0",
+    "version": "5.1.1",
     "author": "Avi Fenesh",
     "author_url": "https://github.com/avifenesh"
   },


### PR DESCRIPTION
## Summary
- bump agentsys version to 5.1.1 across stamped files and cut changelog release entry
- fix installer marketplace source handling for structured `source` objects and `.git` repository URLs
- harden plugin fetch flow with ref fallback (`vX.Y.Z`, `X.Y.Z`, `main`, `master`) and fail-fast behavior on fetch errors
- fix install ordering so local install reset does not wipe fetched plugin cache before platform installs
- add CLI regression tests for source normalization and GitHub source parsing

## Test Plan
- npm test
- npm test -- cli-subcommands.test.js
- npx agentsys-dev validate consistency
- npx agentsys-dev preflight --release
- npm pack --dry-run
- npm pack && npm install -g ./agentsys-5.1.1.tgz && echo "1 2 3" | agentsys
