### PR TITLE
feat: transform Task() to subagent delegation and AskUserQuestion to markdown (#279, #280)

### DIFF
--- a/__tests__/gen-adapters.test.js
+++ b/__tests__/gen-adapters.test.js
@@ -599,13 +599,45 @@ describe('Kiro transforms', () => {
       expect(result).toContain('# Command');
     });
 
-    test('strips Task() calls and replaces with agent reference', () => {
-      const input = 'await Task({ subagent_type: "next-task:exploration-agent", prompt: "explore" });';
+    test('transforms Task() calls into subagent delegation with prompt', () => {
+      const input = 'await Task({ subagent_type: "next-task:exploration-agent", prompt: "explore the codebase" });';
       const result = transforms.transformCommandForKiro(input, {
         pluginInstallPath: '/tmp', name: 'test', description: 'test'
       });
-      expect(result).toContain('Invoke the exploration-agent agent');
+      expect(result).toContain('Delegate to the `exploration-agent` subagent:');
+      expect(result).toContain('> explore the codebase');
       expect(result).not.toContain('Task(');
+    });
+
+    test('transforms Task() calls without prompt into simple delegation', () => {
+      const input = 'await Task({ subagent_type: "deslop:deslop-agent" });';
+      const result = transforms.transformCommandForKiro(input, {
+        pluginInstallPath: '/tmp', name: 'test', description: 'test'
+      });
+      expect(result).toContain('Delegate to the `deslop-agent` subagent.');
+      expect(result).not.toContain('Task(');
+    });
+
+    test('transforms AskUserQuestion into markdown prompt', () => {
+      const input = `AskUserQuestion({ questions: [{ question: "Which task?", header: "Task", options: [{ label: "Bug fix", description: "Fix the auth issue" }, { label: "Feature", description: "Add dark mode" }] }] });`;
+      const result = transforms.transformCommandForKiro(input, {
+        pluginInstallPath: '/tmp', name: 'test', description: 'test'
+      });
+      expect(result).toContain('**Which task?**');
+      expect(result).toContain('1. **Bug fix** - Fix the auth issue');
+      expect(result).toContain('2. **Feature** - Add dark mode');
+      expect(result).toContain('Reply with the number or name of your choice.');
+      expect(result).not.toContain('AskUserQuestion');
+    });
+
+    test('transforms AskUserQuestion without parseable options into simple prompt', () => {
+      const input = 'await AskUserQuestion({ questions: [{ question: "What next?" }] });';
+      const result = transforms.transformCommandForKiro(input, {
+        pluginInstallPath: '/tmp', name: 'test', description: 'test'
+      });
+      expect(result).toContain('**What next?**');
+      expect(result).toContain('Reply in chat with your choice.');
+      expect(result).not.toContain('AskUserQuestion');
     });
 
     test('strips namespace prefixes', () => {

--- a/lib/adapter-transforms.js
+++ b/lib/adapter-transforms.js
@@ -486,10 +486,28 @@ function transformCommandForKiro(content, options) {
 
   content = content.replace(/await\s+Task\s*\(\s*\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}\s*\);?/g, (match) => {
     const agentMatch = match.match(/subagent_type:\s*["'](?:[^"':]+:)?([^"']+)["']/);
+    const promptMatch = match.match(/prompt:\s*[`"']([\s\S]*?)[`"']/);
     if (agentMatch) {
-      return `Invoke the ${agentMatch[1]} agent`;
+      const agentName = agentMatch[1];
+      const prompt = promptMatch ? promptMatch[1].replace(/\\n/g, '\n').trim() : '';
+      if (prompt) {
+        return `Delegate to the \`${agentName}\` subagent:\n> ${prompt.split('\n')[0]}`;
+      }
+      return `Delegate to the \`${agentName}\` subagent.`;
     }
     return '';
+  });
+
+  // Transform AskUserQuestion to markdown prompt for Kiro chat
+  content = content.replace(/(?:await\s+)?AskUserQuestion\s*\(\s*\{[\s\S]*?\}\s*\);?/g, (match) => {
+    const questionMatch = match.match(/question:\s*["'`]([\s\S]*?)["'`]/);
+    const question = questionMatch ? questionMatch[1] : 'Please choose:';
+    const optionMatches = [...match.matchAll(/label:\s*["'`]([^"'`]+)["'`][\s\S]*?description:\s*["'`]([^"'`]+)["'`]/g)];
+    if (optionMatches.length > 0) {
+      const options = optionMatches.map((m, i) => `${i + 1}. **${m[1]}** - ${m[2]}`).join('\n');
+      return `**${question}**\n\n${options}\n\nReply with the number or name of your choice.`;
+    }
+    return `**${question}**\n\nReply in chat with your choice.`;
   });
 
   content = content.replace(/(?:next-task|deslop|ship|sync-docs|audit-project|enhance|perf|repo-map|drift-detect|consult|debate|learn|web-ctl):([a-z][a-z0-9-]*)/g, '$1');


### PR DESCRIPTION
## Summary

Improves how agentsys transforms Claude Code-specific patterns for the Kiro platform:

- **Task() calls** now produce subagent delegation instructions (`Delegate to the \`agent-name\` subagent:`) with extracted prompt text, instead of generic "Invoke the X agent" text. This instructs the Kiro agent to use its native subagent invocation system.
- **AskUserQuestion calls** are transformed to markdown numbered-list prompts, preserving question text, option labels, and descriptions. Kiro has no structured question API, so this gives users a chat-friendly interaction pattern.

## Changes

- `lib/adapter-transforms.js` - Updated `transformCommandForKiro()`:
  - Task() → `Delegate to the \`agent-name\` subagent:\n> prompt text`
  - AskUserQuestion() → `**Question?**\n\n1. **Option** - Description\n\nReply with your choice.`
- `__tests__/gen-adapters.test.js` - 4 new tests (subagent with prompt, subagent without prompt, AskUserQuestion with options, AskUserQuestion without options)

## Test plan

- [x] 3,074+ tests pass
- [x] Task() with prompt extracts first line into blockquote
- [x] Task() without prompt produces simple delegation
- [x] AskUserQuestion with options produces numbered list
- [x] AskUserQuestion without parseable options produces simple prompt
- [x] Pre-push validation: 9/9 checks passed

Closes #279, closes #280