### PR TITLE
Potential fix for code scanning alert no. 105: Inefficient regular expression

### DIFF
--- a/__tests__/gen-adapters.test.js
+++ b/__tests__/gen-adapters.test.js
@@ -826,6 +826,17 @@ describe('Kiro transforms', () => {
       expect(result).toContain('Delegate to the `test-checker` subagent');
       expect(result).not.toContain('Review phase (Kiro');
     });
+
+    test('handles prompts containing standalone $ characters (e.g. $100)', () => {
+      const input = '---\nname: test\n---\n```javascript\nconst r = await Promise.all([\n' +
+        "  Task({ subagent_type: 'cost-checker', model: 'sonnet', prompt: `Check that cost is under $100.` }),\n" +
+        "  Task({ subagent_type: 'budget-agent', model: 'sonnet', prompt: `Ensure $BUDGET is not exceeded.` })\n" +
+        ']);\n```';
+      const result = transforms.transformCommandForKiro(input, { pluginInstallPath: '/tmp', name: 'test', description: 'test' });
+      expect(result).toContain('Delegate to the `cost-checker` subagent');
+      expect(result).toContain('cost is under $100');
+      expect(result).toContain('Delegate to the `budget-agent` subagent');
+    });
   });
 });
 

--- a/lib/adapter-transforms.js
+++ b/lib/adapter-transforms.js
@@ -490,6 +490,8 @@ function transformCommandForKiro(content, options) {
   // template literals inside the code as false fence endings.
   content = content.replace(/^```(?:javascript|js)?\n([\s\S]*?)^```$/gm, (fullBlock, codeContent) => {
     if (!codeContent.includes('Promise.all') || !codeContent.includes('Task(')) return fullBlock;
+    // Use lazy [\s\S]*? for the template literal body: it stops at the first backtick and
+    // naturally matches any character including standalone $ (e.g. $100, $BUDGET).
     const taskMatches = [...codeContent.matchAll(/Task\s*\(\s*\{[\s\S]*?subagent_type:\s*['"](?:[^"':]+:)?([^'"]+)['"][\s\S]*?prompt:\s*`([\s\S]*?)`/gs)];
     if (taskMatches.length < 2) return fullBlock;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1329,7 +1328,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",


### PR DESCRIPTION
Potential fix for [https://github.com/agent-sh/agentsys/security/code-scanning/105](https://github.com/agent-sh/agentsys/security/code-scanning/105)

In general, to fix this kind of inefficiency you remove ambiguity inside the repeated part of the regex so that the engine has only one way to consume each prefix of the input. For template‑literal‑like content, a standard safe pattern is “match any run of non‑special characters, or a single, clearly delimited special construct, and repeat that,” rather than “match either a single character or a multi‑character construct with overlapping possibilities.”

Here, the problematic portion is in the regex on line 493:

```js
const taskMatches = [...codeContent.matchAll(
  /Task\s*\(\s*\{[\s\S]*?subagent_type:\s*['"](?:[^"':]+:)?([^'"]+)['"][\s\S]*?prompt:\s*`((?:[^`]|\$\{[^}]*\})*)`/gs
)];
```

The unsafe fragment is `(?:[^`]|\$\{[^}]*\})*`. Functionally, it tries to match the content of a JavaScript template literal: either any non‑backtick character, or a `${...}` interpolation. The ambiguity arises because the first branch `[^`]` can match the `$` or `{` characters that also start the second branch.

A safer, equivalent approach is:

- Match runs of characters that are neither backtick nor `$`: `[^`$]+`
- Or match a `${...}` interpolation in a way that does not itself contain nested ambiguous repetition. A simple, non‑nested version is `\$\{[^}]*\}` which is fine, since its internal `*` sits in a different alternation and does not conflict with the outer one, as long as the first branch of the alternation does *not* match `$`.

Combining those:

```js
`((?:[^`$]+|\$\{[^}]*\})*)`
```

Now the only characters that start the second branch (`$`) are explicitly excluded from the first branch, eliminating overlap and exponential backtracking, while preserving the intent: match zero or more of (plain template text without `$`) or `${...}` interpolations, until the closing backtick.

So the fix is:

- In `lib/adapter-transforms.js`, around line 493, replace the regex’s inner capture from
  - `` `((?:[^`]|\$\{[^}]*\})*)` ``
  - to
  - `` `((?:[^`$]+|\$\{[^}]*\})*)` ``

No new imports or helper methods are needed; only the regex literal changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
