### PR TITLE
docs: align agent/rule counts with reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,7 +657,7 @@ Findings are collected and categorized by severity (critical/high/medium/low). A
 - AST symbol mapping: exports, functions, classes, imports
 - Project metadata and health metrics
 
-Output is cached at `{state-dir}/repo-intel.json` (where `{state-dir}` is `.claude/`, `.opencode/`, or `.codex/` depending on your platform).
+Output is cached at `{state-dir}/repo-intel.json` (external repo-intel plugin) and `{state-dir}/repo-map.json` (agentsys internal repo-map library). `{state-dir}` is `.claude/`, `.opencode/`, or `.codex/` depending on your platform.
 
 **Why it matters:**
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <b>19 plugins · 47 agents · 40 skills (across all repos) · 30k lines of lib code · 3,583 tests · 5 platforms</b><br>
+  <b>19 plugins · 39 agents · 40 skills (across all repos) · 30k lines of lib code · 3,583 tests · 5 platforms</b><br>
   <em>Plugins distributed as standalone repos under <a href="https://github.com/agent-sh">agent-sh</a> org — agentsys is the marketplace &amp; installer</em>
 </p>
 
@@ -41,11 +41,11 @@
 AI models can write code. That's not the hard part anymore. The hard part is everything around it — task selection, branch management, code review, artifact cleanup, CI, PR comments, deployment. **AgentSys is the runtime that orchestrates agents to handle all of it** — structured pipelines, gated phases, specialized agents, and persistent state that survives session boundaries.
 
 ---
-> Building custom skills, agents, hooks, or MCP tools? [agnix](https://github.com/agent-sh/agnix) is the CLI + LSP linter that catches config errors before they fail silently - real-time IDE validation, auto suggestions, auto-fix, and 385 rules for Claude Code, Codex, OpenCode, Cursor, Kiro, Copilot, Gemini CLI, Cline, Windsurf, Roo Code, Amp, and more.
+> Building custom skills, agents, hooks, or MCP tools? [agnix](https://github.com/agent-sh/agnix) is the CLI + LSP linter that catches config errors before they fail silently - real-time IDE validation, auto suggestions, auto-fix, and 399 rules for Claude Code, Codex, OpenCode, Cursor, Kiro, Copilot, Gemini CLI, Cline, Windsurf, Roo Code, Amp, and more.
 
 ## What This Is
 
-An agent orchestration system — 19 plugins, 47 agents, and 40 skills that compose into structured pipelines for software development. Each plugin lives in its own standalone repo under the [agent-sh](https://github.com/agent-sh) org. agentsys is the marketplace and installer that ties them together.
+An agent orchestration system — 19 plugins, 39 agents, and 40 skills that compose into structured pipelines for software development. Each plugin lives in its own standalone repo under the [agent-sh](https://github.com/agent-sh) org. agentsys is the marketplace and installer that ties them together.
 
 Each agent has a single responsibility, a specific model assignment, and defined inputs/outputs. Pipelines enforce phase gates so agents can't skip steps. State persists across sessions so work survives interruptions.
 
@@ -118,7 +118,7 @@ The investment shifts from model spend to pipeline design. Better prompts, riche
 | [`/next-task`](#next-task) | Task workflow: discovery, implementation, PR, merge |
 | [`/prepare-delivery`](#prepare-delivery) | Pre-ship quality gates: deslop, review, validation, docs sync |
 | [`/gate-and-ship`](#gate-and-ship) | Quality gates then ship (/prepare-delivery + /ship) |
-| [`/agnix`](#agnix) | Lint agent configurations (385 rules) |
+| [`/agnix`](#agnix) | Lint agent configurations (399 rules) |
 | [`/ship`](#ship) | PR creation, CI monitoring, merge |
 | [`/deslop`](#deslop) | Clean AI slop patterns |
 | [`/perf`](#perf) | Performance investigation with baselines and profiling |
@@ -328,7 +328,7 @@ agnix catches these issues before they cause problems.
 | **Best Practices** | Tool restrictions, model selection, trigger phrase quality |
 | **Cross-Platform** | Compatibility across Claude Code, Codex, OpenCode, Cursor, Kiro, Copilot, Gemini CLI, Cline, Windsurf, Roo Code, Amp, and more |
 
-**385 validation rules** (102 auto-fixable) derived from:
+**399 validation rules** (126 auto-fixable) derived from:
 - Official tool specifications (Claude Code, Codex CLI, OpenCode, Cursor, Kiro, GitHub Copilot, Gemini CLI, Cline, Windsurf, Roo Code, Amp, and more)
 - Research papers on agent reliability and prompt injection
 - Real-world testing across 500+ repositories
@@ -613,13 +613,14 @@ Findings are collected and categorized by severity (critical/high/medium/low). A
 
 **Purpose:** Analyzes your prompts, plugins, agents, docs, hooks, and skills for improvement opportunities.
 
-**Seven analyzers run in parallel:**
+**Eight analyzers run in parallel:**
 
 | Analyzer | What it checks |
 |----------|----------------|
 | plugin-enhancer | Plugin structure, MCP tool definitions, security patterns |
 | agent-enhancer | Agent frontmatter, prompt quality |
 | claudemd-enhancer | CLAUDE.md/AGENTS.md structure, token efficiency |
+| cross-file-enhancer | Cross-file consistency (tools vs frontmatter, duplicate rules, conflicts) |
 | docs-enhancer | Documentation readability, RAG optimization |
 | prompt-enhancer | Prompt engineering patterns, clarity, examples |
 | hooks-enhancer | Hook frontmatter, structure, safety |
@@ -656,7 +657,7 @@ Findings are collected and categorized by severity (critical/high/medium/low). A
 - AST symbol mapping: exports, functions, classes, imports
 - Project metadata and health metrics
 
-Output is cached at `{state-dir}/repo-intel.json` and `{state-dir}/repo-map.json`.
+Output is cached at `{state-dir}/repo-intel.json` (where `{state-dir}` is `.claude/`, `.opencode/`, or `.codex/` depending on your platform).
 
 **Why it matters:**
 
@@ -958,7 +959,7 @@ No per-turn overhead - it reads transcripts that Claude Code already saves.
 **What happens when you run it:**
 
 1. **Collect** (68ms median) - Pure JavaScript scans manifest, structure, README, CI, git info. Normal depth adds CLAUDE.md/AGENTS.md and repo-intel. No LLM tokens.
-2. **Synthesize** - Opus agent produces a structured overview: tech stack, key files, active areas, conventions
+2. **Synthesize** - Sonnet agent produces a structured overview: tech stack, key files, active areas, conventions
 3. **Guide** - Interactive Q&A: ask about specific files, areas, or patterns
 
 **74% fewer tokens** than manual onboarding. Validated on 100 repos across JS/TS, Rust, Go, Python, C/C++, Java, and Deno.
@@ -981,7 +982,7 @@ No per-turn overhead - it reads transcripts that Claude Code already saves.
 /onboard --depth=deep       # Include AST data
 ```
 
-**Agent:** onboard-agent (opus model)
+**Agent:** onboard-agent (sonnet model)
 
 [Full documentation →](https://github.com/agent-sh/onboard)
 
@@ -994,7 +995,7 @@ No per-turn overhead - it reads transcripts that Claude Code already saves.
 **What happens when you run it:**
 
 1. **Collect** - Gathers project data + contributor signals (test gaps, doc drift, bugspots, good-first areas, open issues). Validated on 100 repos.
-2. **Match** - Opus agent asks about developer background and matches skills to project needs
+2. **Match** - Sonnet agent asks about developer background and matches skills to project needs
 3. **Guide** - For each recommendation: reads code, explains what needs doing, gives a concrete first step
 
 **Matching:**
@@ -1015,7 +1016,7 @@ No per-turn overhead - it reads transcripts that Claude Code already saves.
 /can-i-help --depth=deep          # Include AST data
 ```
 
-**Agent:** can-i-help-agent (opus model)
+**Agent:** can-i-help-agent (sonnet model)
 
 [Full documentation →](https://github.com/agent-sh/can-i-help)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <b>19 plugins · 39 agents · 40 skills (across all repos) · 30k lines of lib code · 3,583 tests · 5 platforms</b><br>
+  <b>19 plugins · 49 agents · 40 skills (across all repos) · 30k lines of lib code · 3,583 tests · 5 platforms</b><br>
   <em>Plugins distributed as standalone repos under <a href="https://github.com/agent-sh">agent-sh</a> org — agentsys is the marketplace &amp; installer</em>
 </p>
 
@@ -45,7 +45,7 @@ AI models can write code. That's not the hard part anymore. The hard part is eve
 
 ## What This Is
 
-An agent orchestration system — 19 plugins, 39 agents, and 40 skills that compose into structured pipelines for software development. Each plugin lives in its own standalone repo under the [agent-sh](https://github.com/agent-sh) org. agentsys is the marketplace and installer that ties them together.
+An agent orchestration system — 19 plugins, 49 agents (39 file-based + 10 role-based specialists in audit-project), and 40 skills that compose into structured pipelines for software development. Each plugin lives in its own standalone repo under the [agent-sh](https://github.com/agent-sh) org. agentsys is the marketplace and installer that ties them together.
 
 Each agent has a single responsibility, a specific model assignment, and defined inputs/outputs. Pipelines enforce phase gates so agents can't skip steps. State persists across sessions so work survives interruptions.
 

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -395,9 +395,10 @@ function generateAgentCounts(agents, plugins) {
 /**
  * Update counts in site/content.json programmatically.
  */
-// Static counts for cross-repo plugins not discoverable locally
+// Static counts for cross-repo plugins not discoverable locally.
+// 39 file-based agents across 17 plugin repos + 10 role-based specialists in audit-project = 49.
 const STATIC_PLUGIN_COUNT = 19;
-const STATIC_AGENT_COUNT = 47;
+const STATIC_AGENT_COUNT = 49;
 
 function updateSiteContent(plugins, agents, skills) {
   const contentPath = path.join(ROOT_DIR, 'site', 'content.json');

--- a/site/content.json
+++ b/site/content.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "agentsys",
-    "description": "A modular runtime and orchestration system for AI agents. 19 plugins, 39 agents, 40 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.",
+    "description": "A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 40 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.",
     "url": "https://agent-sh.github.io/agentsys",
     "repo": "https://github.com/agent-sh/agentsys",
     "npm": "https://www.npmjs.com/package/agentsys",

--- a/site/content.json
+++ b/site/content.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "agentsys",
-    "description": "A modular runtime and orchestration system for AI agents. 19 plugins, 47 agents, 40 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.",
+    "description": "A modular runtime and orchestration system for AI agents. 19 plugins, 39 agents, 40 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.",
     "url": "https://agent-sh.github.io/agentsys",
     "repo": "https://github.com/agent-sh/agentsys",
     "npm": "https://www.npmjs.com/package/agentsys",
@@ -112,7 +112,7 @@
     {
       "name": "/agnix",
       "tagline": "Lint agent configs before they break",
-      "description": "385 validation rules (102 auto-fixable) for Skills, Memory, Hooks, MCP, and Plugins across 10+ AI tools including Claude Code, Cursor, GitHub Copilot, Codex CLI, OpenCode, Gemini CLI, Cline, Windsurf, Roo Code, and Amp. SARIF output for GitHub Code Scanning.",
+      "description": "399 validation rules (126 auto-fixable) for Skills, Memory, Hooks, MCP, and Plugins across 10+ AI tools including Claude Code, Cursor, GitHub Copilot, Codex CLI, OpenCode, Gemini CLI, Cline, Windsurf, Roo Code, and Amp. SARIF output for GitHub Code Scanning.",
       "example": "/agnix --fix",
       "category": "linting"
     },

--- a/site/content.json
+++ b/site/content.json
@@ -28,7 +28,7 @@
       "suffix": ""
     },
     {
-      "value": "39",
+      "value": "49",
       "label": "Agents",
       "suffix": ""
     },
@@ -373,7 +373,7 @@
     }
   ],
   "agents": {
-    "total": 39,
+    "total": 49,
     "file_based": 39,
     "role_based": 10,
     "by_model": [

--- a/site/content.json
+++ b/site/content.json
@@ -28,7 +28,7 @@
       "suffix": ""
     },
     {
-      "value": "47",
+      "value": "39",
       "label": "Agents",
       "suffix": ""
     },
@@ -154,7 +154,7 @@
     {
       "name": "/enhance",
       "tagline": "Analyze everything that shapes agent behavior",
-      "description": "Seven parallel analyzers check your prompts, agents, plugins, docs, hooks, and skills. Certainty-graded findings with auto-fix support. Auto-learns false positives over time.",
+      "description": "Eight parallel analyzers check your prompts, agents, plugins, docs, hooks, and skills. Certainty-graded findings with auto-fix support. Auto-learns false positives over time.",
       "example": "/enhance",
       "category": "analysis"
     },
@@ -373,8 +373,8 @@
     }
   ],
   "agents": {
-    "total": 47,
-    "file_based": 37,
+    "total": 39,
+    "file_based": 39,
     "role_based": 10,
     "by_model": [
       {

--- a/site/index.html
+++ b/site/index.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>AgentSys - Agent Runtime &amp; Orchestration System</title>
-  <meta name="description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 47 agents, 40 skills — structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
+  <meta name="description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 39 agents, 40 skills — structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
   <meta name="theme-color" content="#09090b">
 
   <!-- Open Graph -->
   <meta property="og:title" content="AgentSys">
-  <meta property="og:description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 47 agents, 40 skills.">
+  <meta property="og:description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 39 agents, 40 skills.">
   <meta property="og:image" content="https://agent-sh.github.io/agentsys/assets/logo.png">
   <meta property="og:url" content="https://agent-sh.github.io/agentsys/">
   <meta property="og:type" content="website">
@@ -17,7 +17,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="AgentSys">
-  <meta name="twitter:description" content="AI workflow automation. 19 plugins, 47 agents, 40 skills.">
+  <meta name="twitter:description" content="AI workflow automation. 19 plugins, 39 agents, 40 skills.">
   <meta name="twitter:image" content="https://agent-sh.github.io/agentsys/assets/logo.png">
 
   <!-- Content Security Policy -->
@@ -107,7 +107,7 @@
       <div class="hero__inner">
         <div class="hero__content">
           <div class="hero__badge anim-fade-in" data-delay="100">
-            19 plugins &middot; 47 agents &middot; 40 skills
+            19 plugins &middot; 39 agents &middot; 40 skills
           </div>
           <h1 class="hero__title anim-fade-up" id="hero-title" data-delay="200">
             A modular <span class="text-gradient">runtime and orchestration system</span><br>
@@ -160,7 +160,7 @@
           <span class="stats__label">Plugins</span>
         </div>
         <div class="stats__item">
-          <span class="stats__number" aria-live="polite" data-target="47">0</span>
+          <span class="stats__number" aria-live="polite" data-target="39">0</span>
           <span class="stats__label">Agents</span>
         </div>
         <div class="stats__item">
@@ -228,9 +228,9 @@
             <h3 class="tabs__panel-name">/agnix</h3>
             <p class="tabs__panel-tagline">Lint agent configs before they break</p>
             <ul class="tabs__panel-features">
-              <li>385 validation rules across 36 categories</li>
+              <li>399 validation rules across 36 categories</li>
               <li>10+ AI tools: Claude Code, Cursor, Copilot, Codex, OpenCode, Gemini CLI</li>
-              <li>102 auto-fixable rules with --fix flag</li>
+              <li>126 auto-fixable rules with --fix flag</li>
               <li>SARIF output for GitHub Code Scanning</li>
             </ul>
             <div class="code-block">

--- a/site/index.html
+++ b/site/index.html
@@ -607,7 +607,7 @@
               <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="3"/></svg>
             </div>
             <h3 class="philosophy__card-title">One agent, one job, done well</h3>
-            <p class="philosophy__card-desc"><span class="text-accent">47 specialized agents</span>, each with a narrow scope and clear success criteria. No agent tries to do everything.</p>
+            <p class="philosophy__card-desc"><span class="text-accent">39 specialized agents</span>, each with a narrow scope and clear success criteria. No agent tries to do everything.</p>
           </div>
           <div class="philosophy__card anim-fade-up" data-delay="200">
             <div class="philosophy__card-icon">
@@ -662,7 +662,7 @@
     <!-- ===== AGENTS & SKILLS ===== -->
     <section class="agents-skills" id="agents-skills" aria-labelledby="as-title">
       <div class="agents-skills__inner">
-        <h2 class="agents-skills__title anim-fade-up" id="as-title">47 Agents. 40 Skills.</h2>
+        <h2 class="agents-skills__title anim-fade-up" id="as-title">39 Agents. 40 Skills.</h2>
         <p class="agents-skills__subtitle anim-fade-up" data-delay="100">Right model for the task. Opus reasons. Sonnet validates. Haiku executes.</p>
 
         <!-- Agent tier tabs -->

--- a/site/index.html
+++ b/site/index.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>AgentSys - Agent Runtime &amp; Orchestration System</title>
-  <meta name="description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 39 agents, 40 skills — structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
+  <meta name="description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 40 skills — structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
   <meta name="theme-color" content="#09090b">
 
   <!-- Open Graph -->
   <meta property="og:title" content="AgentSys">
-  <meta property="og:description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 39 agents, 40 skills.">
+  <meta property="og:description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 40 skills.">
   <meta property="og:image" content="https://agent-sh.github.io/agentsys/assets/logo.png">
   <meta property="og:url" content="https://agent-sh.github.io/agentsys/">
   <meta property="og:type" content="website">
@@ -17,7 +17,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="AgentSys">
-  <meta name="twitter:description" content="AI workflow automation. 19 plugins, 39 agents, 40 skills.">
+  <meta name="twitter:description" content="AI workflow automation. 19 plugins, 49 agents, 40 skills.">
   <meta name="twitter:image" content="https://agent-sh.github.io/agentsys/assets/logo.png">
 
   <!-- Content Security Policy -->
@@ -107,7 +107,7 @@
       <div class="hero__inner">
         <div class="hero__content">
           <div class="hero__badge anim-fade-in" data-delay="100">
-            19 plugins &middot; 39 agents &middot; 40 skills
+            19 plugins &middot; 49 agents &middot; 40 skills
           </div>
           <h1 class="hero__title anim-fade-up" id="hero-title" data-delay="200">
             A modular <span class="text-gradient">runtime and orchestration system</span><br>
@@ -160,7 +160,7 @@
           <span class="stats__label">Plugins</span>
         </div>
         <div class="stats__item">
-          <span class="stats__number" aria-live="polite" data-target="39">0</span>
+          <span class="stats__number" aria-live="polite" data-target="49">0</span>
           <span class="stats__label">Agents</span>
         </div>
         <div class="stats__item">
@@ -607,7 +607,7 @@
               <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="3"/></svg>
             </div>
             <h3 class="philosophy__card-title">One agent, one job, done well</h3>
-            <p class="philosophy__card-desc"><span class="text-accent">39 specialized agents</span>, each with a narrow scope and clear success criteria. No agent tries to do everything.</p>
+            <p class="philosophy__card-desc"><span class="text-accent">49 specialized agents</span>, each with a narrow scope and clear success criteria. No agent tries to do everything.</p>
           </div>
           <div class="philosophy__card anim-fade-up" data-delay="200">
             <div class="philosophy__card-icon">
@@ -662,7 +662,7 @@
     <!-- ===== AGENTS & SKILLS ===== -->
     <section class="agents-skills" id="agents-skills" aria-labelledby="as-title">
       <div class="agents-skills__inner">
-        <h2 class="agents-skills__title anim-fade-up" id="as-title">39 Agents. 40 Skills.</h2>
+        <h2 class="agents-skills__title anim-fade-up" id="as-title">49 Agents. 40 Skills.</h2>
         <p class="agents-skills__subtitle anim-fade-up" data-delay="100">Right model for the task. Opus reasons. Sonnet validates. Haiku executes.</p>
 
         <!-- Agent tier tabs -->

--- a/site/ux-spec.md
+++ b/site/ux-spec.md
@@ -94,7 +94,7 @@ Scroll order with rationale for each section. All sections are full-width, alter
 - **Single column on mobile:** Text above, terminal below. Stack with 48px gap.
 
 ### Left Column Content
-1. **Badge** (top, above title): Small pill showing version or "19 plugins . 47 agents . 40 skills"
+1. **Badge** (top, above title): Small pill showing version or "19 plugins . 39 agents . 40 skills"
    - Background: `rgba(99, 102, 241, 0.12)`, border: `1px solid rgba(99, 102, 241, 0.25)`, border-radius: 9999px
    - Font: 13px, font-weight 500, primary accent color
    - Padding: 4px 14px
@@ -104,7 +104,7 @@ Scroll order with rationale for each section. All sections are full-width, alter
    - Color: white
    - "entire dev workflow" portion highlighted with a subtle gradient text (primary-to-secondary accent via `background-clip: text`)
 
-3. **Subtitle:** "19 plugins, 47 agents, 40 skills. From task selection to merged PR. Works with Claude Code, OpenCode, Codex CLI, Cursor, and Kiro."
+3. **Subtitle:** "19 plugins, 39 agents, 40 skills. From task selection to merged PR. Works with Claude Code, OpenCode, Codex CLI, Cursor, and Kiro."
    - Font: 18px on desktop, 16px on mobile, font-weight 400, line-height 1.6
    - Color: `rgba(255, 255, 255, 0.6)`
    - Max-width: 520px
@@ -650,13 +650,13 @@ This disables:
 ### Head Content
 ```html
 <title>AgentSys - Agent Runtime &amp; Orchestration System</title>
-<meta name="description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 47 agents, 40 skills — structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
+<meta name="description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 39 agents, 40 skills — structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="theme-color" content="#0a0a0f">
 
 <!-- Open Graph -->
 <meta property="og:title" content="AgentSys">
-<meta property="og:description" content="AI workflow automation. 19 plugins, 47 agents, 40 skills. Task to merged PR.">
+<meta property="og:description" content="AI workflow automation. 19 plugins, 39 agents, 40 skills. Task to merged PR.">
 <meta property="og:image" content="https://agent-sh.github.io/agentsys/assets/og-image.png">
 <meta property="og:url" content="https://agent-sh.github.io/agentsys/">
 <meta property="og:type" content="website">
@@ -664,7 +664,7 @@ This disables:
 <!-- Twitter Card -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AgentSys">
-<meta name="twitter:description" content="AI workflow automation. 19 plugins, 47 agents, 40 skills.">
+<meta name="twitter:description" content="AI workflow automation. 19 plugins, 39 agents, 40 skills.">
 <meta name="twitter:image" content="https://agent-sh.github.io/agentsys/assets/og-image.png">
 ```
 

--- a/site/ux-spec.md
+++ b/site/ux-spec.md
@@ -94,7 +94,7 @@ Scroll order with rationale for each section. All sections are full-width, alter
 - **Single column on mobile:** Text above, terminal below. Stack with 48px gap.
 
 ### Left Column Content
-1. **Badge** (top, above title): Small pill showing version or "19 plugins . 39 agents . 40 skills"
+1. **Badge** (top, above title): Small pill showing version or "19 plugins . 49 agents . 40 skills"
    - Background: `rgba(99, 102, 241, 0.12)`, border: `1px solid rgba(99, 102, 241, 0.25)`, border-radius: 9999px
    - Font: 13px, font-weight 500, primary accent color
    - Padding: 4px 14px
@@ -104,7 +104,7 @@ Scroll order with rationale for each section. All sections are full-width, alter
    - Color: white
    - "entire dev workflow" portion highlighted with a subtle gradient text (primary-to-secondary accent via `background-clip: text`)
 
-3. **Subtitle:** "19 plugins, 39 agents, 40 skills. From task selection to merged PR. Works with Claude Code, OpenCode, Codex CLI, Cursor, and Kiro."
+3. **Subtitle:** "19 plugins, 49 agents, 40 skills. From task selection to merged PR. Works with Claude Code, OpenCode, Codex CLI, Cursor, and Kiro."
    - Font: 18px on desktop, 16px on mobile, font-weight 400, line-height 1.6
    - Color: `rgba(255, 255, 255, 0.6)`
    - Max-width: 520px
@@ -650,13 +650,13 @@ This disables:
 ### Head Content
 ```html
 <title>AgentSys - Agent Runtime &amp; Orchestration System</title>
-<meta name="description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 39 agents, 40 skills — structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
+<meta name="description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 40 skills — structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="theme-color" content="#0a0a0f">
 
 <!-- Open Graph -->
 <meta property="og:title" content="AgentSys">
-<meta property="og:description" content="AI workflow automation. 19 plugins, 39 agents, 40 skills. Task to merged PR.">
+<meta property="og:description" content="AI workflow automation. 19 plugins, 49 agents, 40 skills. Task to merged PR.">
 <meta property="og:image" content="https://agent-sh.github.io/agentsys/assets/og-image.png">
 <meta property="og:url" content="https://agent-sh.github.io/agentsys/">
 <meta property="og:type" content="website">
@@ -664,7 +664,7 @@ This disables:
 <!-- Twitter Card -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AgentSys">
-<meta name="twitter:description" content="AI workflow automation. 19 plugins, 39 agents, 40 skills.">
+<meta name="twitter:description" content="AI workflow automation. 19 plugins, 49 agents, 40 skills.">
 <meta name="twitter:image" content="https://agent-sh.github.io/agentsys/assets/og-image.png">
 ```
 


### PR DESCRIPTION
## Summary
Aligns user-facing counts with reality: agent count goes from stale "47" to actual **49** (39 file-based agents across 17 plugin repos + 10 role-based specialists dynamically spawned by audit-project). Also fixes agnix rule count 385 → 399 (and auto-fixable 102 → 126), adds missing cross-file-enhancer, and flips onboard/can-i-help model references from Opus to Sonnet to match the agent frontmatter.

## Why
Detected during a workspace-wide repo-intel doc-drift scan. Docs claimed numbers/names that no longer match the code.

## Changes
- **Agent count 47 → 49** in README, site/index.html (meta/og/twitter/hero/stats/philosophy/section title), site/content.json (meta.description, stats, agents.total), site/ux-spec.md
- **scripts/generate-docs.js**: `STATIC_AGENT_COUNT` 47 → 49 with clarifying comment explaining the 39 file-based + 10 role-based formula
- **agnix rule count 385 → 399** (3 locations in README, 1 in /agnix command tagline, 1 in content.json /agnix description)
- **agnix auto-fixable 102 → 126**
- **Enhance analyzers 7 → 8**: added `cross-file-enhancer` row to README Analyzers table
- **onboard-agent / can-i-help-agent**: opus → sonnet in 5 prose references (match frontmatter)
- **repo-intel caching note**: clarified both `repo-intel.json` (external plugin) and `repo-map.json` (agentsys internal lib/repo-map/) are used

## Test plan
- [x] `npm test` passes (3447 passed, 0 failed)
- [x] `gen-docs --check` returns fresh (generate-docs.test.js green)
- [x] `npm run validate` passes
- [x] Counts match: README hero = content.json stats = index.html data-target = 49

Docs-only change (except for 1-line STATIC_AGENT_COUNT constant in generate-docs.js).