### PR TITLE
docs: replace em-dashes with hyphens per workspace rule 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 <p align="center">
   <b>19 plugins · 49 agents · 40 skills (across all repos) · 30k lines of lib code · 3,583 tests · 5 platforms</b><br>
-  <em>Plugins distributed as standalone repos under <a href="https://github.com/agent-sh">agent-sh</a> org — agentsys is the marketplace &amp; installer</em>
+  <em>Plugins distributed as standalone repos under <a href="https://github.com/agent-sh">agent-sh</a> org - agentsys is the marketplace &amp; installer</em>
 </p>
 
 <p align="center">
@@ -38,14 +38,14 @@
 
 ---
 
-AI models can write code. That's not the hard part anymore. The hard part is everything around it — task selection, branch management, code review, artifact cleanup, CI, PR comments, deployment. **AgentSys is the runtime that orchestrates agents to handle all of it** — structured pipelines, gated phases, specialized agents, and persistent state that survives session boundaries.
+AI models can write code. That's not the hard part anymore. The hard part is everything around it - task selection, branch management, code review, artifact cleanup, CI, PR comments, deployment. **AgentSys is the runtime that orchestrates agents to handle all of it** - structured pipelines, gated phases, specialized agents, and persistent state that survives session boundaries.
 
 ---
 > Building custom skills, agents, hooks, or MCP tools? [agnix](https://github.com/agent-sh/agnix) is the CLI + LSP linter that catches config errors before they fail silently - real-time IDE validation, auto suggestions, auto-fix, and 399 rules for Claude Code, Codex, OpenCode, Cursor, Kiro, Copilot, Gemini CLI, Cline, Windsurf, Roo Code, Amp, and more.
 
 ## What This Is
 
-An agent orchestration system — 19 plugins, 49 agents (39 file-based + 10 role-based specialists in audit-project), and 40 skills that compose into structured pipelines for software development. Each plugin lives in its own standalone repo under the [agent-sh](https://github.com/agent-sh) org. agentsys is the marketplace and installer that ties them together.
+An agent orchestration system - 19 plugins, 49 agents (39 file-based + 10 role-based specialists in audit-project), and 40 skills that compose into structured pipelines for software development. Each plugin lives in its own standalone repo under the [agent-sh](https://github.com/agent-sh) org. agentsys is the marketplace and installer that ties them together.
 
 Each agent has a single responsibility, a specific model assignment, and defined inputs/outputs. Pipelines enforce phase gates so agents can't skip steps. State persists across sessions so work survives interruptions.
 
@@ -57,8 +57,8 @@ The system runs on Claude Code, OpenCode, Codex CLI, Cursor, and Kiro. Install v
 
 **Code does code work. AI does AI work.**
 
-- **Detection**: regex, AST analysis, static analysis—fast, deterministic, no tokens wasted
-- **Judgment**: LLM calls for synthesis, planning, review—where reasoning matters
+- **Detection**: regex, AST analysis, static analysis - fast, deterministic, no tokens wasted
+- **Judgment**: LLM calls for synthesis, planning, review - where reasoning matters
 - **Result**: 77% fewer tokens for [/drift-detect](#drift-detect) vs multi-agent approaches, certainty-graded findings throughout
 
 **Certainty levels exist because not all findings are equal:**
@@ -442,7 +442,7 @@ If something can't be fixed, the workflow replies explaining why and resolves th
 
 ### /deslop
 
-**Purpose:** Finds AI slop—debug statements, placeholder text, verbose comments, TODOs—and removes it.
+**Purpose:** Finds AI slop - debug statements, placeholder text, verbose comments, TODOs - and removes it.
 
 **How detection works:**
 
@@ -679,7 +679,7 @@ Backed by [agent-analyzer](https://github.com/agent-sh/agent-analyzer) Rust bina
 
 ### /sync-docs
 
-**Purpose:** Sync documentation with actual code changes—find outdated refs, update CHANGELOG, flag stale examples.
+**Purpose:** Sync documentation with actual code changes - find outdated refs, update CHANGELOG, flag stale examples.
 
 **The problem it solves:**
 
@@ -1093,7 +1093,7 @@ Same principle as good code: single responsibility. The exploration-agent explor
 
 **2. Pipeline with gates, not a monolith**
 
-Same principle as DevOps. Each step must pass before the next begins. Can't push before review. Can't merge before CI passes. Hooks enforce this—agents literally cannot skip phases.
+Same principle as DevOps. Each step must pass before the next begins. Can't push before review. Can't merge before CI passes. Hooks enforce this - agents literally cannot skip phases.
 
 **3. Tools do tool work, agents do agent work**
 

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>AgentSys - Agent Runtime &amp; Orchestration System</title>
-  <meta name="description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 40 skills — structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
+  <meta name="description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 40 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
   <meta name="theme-color" content="#09090b">
 
   <!-- Open Graph -->

--- a/site/ux-spec.md
+++ b/site/ux-spec.md
@@ -650,7 +650,7 @@ This disables:
 ### Head Content
 ```html
 <title>AgentSys - Agent Runtime &amp; Orchestration System</title>
-<meta name="description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 40 skills — structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
+<meta name="description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 40 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="theme-color" content="#0a0a0f">
 


### PR DESCRIPTION
## Summary
Replace 12 em-dashes (\`—\`) with \` - \` (hyphen with spaces) in README.md, site/index.html, and site/ux-spec.md.

## Why
Workspace \`CLAUDE.md\` rule 6: *Use single dash for em-dashes - In prose, use \` - \` (single dash with spaces), never \` -- \`*. Gemini flagged these in the #326 review thread.

## Scope
Pure character normalization, no content changes.

## Test plan
- [x] \`npm test\` passes (3507)
- [x] No \`—\` remaining in target files (verified)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only punctuation normalization (em-dashes to spaced hyphens) in `README.md` and site meta/UX spec content; no runtime/code-path changes.
> 
> **Overview**
> **Punctuation normalization only.** Replaces em-dashes (`—`) with spaced hyphens (` - `) across prose in `README.md`, the site `meta name="description"` in `site/index.html`, and the corresponding snippet in `site/ux-spec.md`.
> 
> No functional or behavioral changes; content meaning and structure remain the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b052af33e50dbd24be822259b5f6caf0eef3427. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->