### PR TITLE
docs: add agnix to skills table, align skill count 40 -> 41

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ Each command works standalone. Together, they compose into end-to-end pipelines.
 | **Performance** | `baseline`, `benchmark`, `code-paths`, `investigation-logger`, `perf-analyzer`, `profile`, `theory-gatherer`, `theory-tester` |
 | **Cleanup** | `deslop`, `sync-docs` |
 | **Code Review** | `audit-project` |
-| **Linting** | `agnix` |
 | **AI Collaboration** | `consult`, `debate`, `learn`, `recommend`, `skillers-compact` |
 | **Onboarding** | `can-i-help`, `onboard` |
 | **Web** | `web-auth`, `web-browse` |
 | **Release** | `release` |
 | **Analysis** | `drift-analysis`, `repo-intel` |
+| **Linting** | `agnix` |
 
 **External skill plugins** (standalone repos, installed separately):
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <b>19 plugins · 49 agents · 40 skills (across all repos) · 30k lines of lib code · 3,507 tests · 5 platforms</b><br>
+  <b>19 plugins · 49 agents · 41 skills (across all repos) · 30k lines of lib code · 3,507 tests · 5 platforms</b><br>
   <em>Plugins distributed as standalone repos under <a href="https://github.com/agent-sh">agent-sh</a> org - agentsys is the marketplace &amp; installer</em>
 </p>
 
@@ -45,7 +45,7 @@ AI models can write code. That's not the hard part anymore. The hard part is eve
 
 ## What This Is
 
-An agent orchestration system - 19 plugins, 49 agents (39 file-based + 10 role-based specialists in audit-project), and 40 skills that compose into structured pipelines for software development. Each plugin lives in its own standalone repo under the [agent-sh](https://github.com/agent-sh) org. agentsys is the marketplace and installer that ties them together.
+An agent orchestration system - 19 plugins, 49 agents (39 file-based + 10 role-based specialists in audit-project), and 41 skills that compose into structured pipelines for software development. Each plugin lives in its own standalone repo under the [agent-sh](https://github.com/agent-sh) org. agentsys is the marketplace and installer that ties them together.
 
 Each agent has a single responsibility, a specific model assignment, and defined inputs/outputs. Pipelines enforce phase gates so agents can't skip steps. State persists across sessions so work survives interruptions.
 
@@ -142,7 +142,7 @@ Each command works standalone. Together, they compose into end-to-end pipelines.
 
 ## Skills
 
-40 skills included across the plugins:
+41 skills included across the plugins:
 
 | Category | Skills |
 |----------|--------|
@@ -152,6 +152,7 @@ Each command works standalone. Together, they compose into end-to-end pipelines.
 | **Performance** | `baseline`, `benchmark`, `code-paths`, `investigation-logger`, `perf-analyzer`, `profile`, `theory-gatherer`, `theory-tester` |
 | **Cleanup** | `deslop`, `sync-docs` |
 | **Code Review** | `audit-project` |
+| **Linting** | `agnix` |
 | **AI Collaboration** | `consult`, `debate`, `learn`, `recommend`, `skillers-compact` |
 | **Onboarding** | `can-i-help`, `onboard` |
 | **Web** | `web-auth`, `web-browse` |
@@ -175,7 +176,7 @@ Skills are the reusable implementation units. Agents invoke skills; commands orc
 | [The Approach](#the-approach) | Why it's built this way |
 | [Benchmarks](#benchmarks) | Sonnet + agentsys vs raw Opus |
 | [Commands](#commands) | All 20 commands overview |
-| [Skills](#skills) | 40 skills across plugins |
+| [Skills](#skills) | 41 skills across plugins |
 | [Skill-Only Plugins](#skill-only-plugins) | glide-mq and other non-command plugins |
 | [Command Details](#command-details) | Deep dive into each command |
 | [How Commands Work Together](#how-commands-work-together) | Standalone vs integrated |

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -193,7 +193,7 @@ function generateCommandsTable(commands) {
     'next-task': 'Task workflow: discovery, implementation, PR, merge',
     'prepare-delivery': 'Pre-ship quality gates: deslop, review, validation, docs sync',
     'gate-and-ship': 'Quality gates then ship (/prepare-delivery + /ship)',
-    'agnix': 'Lint agent configurations (385 rules)',
+    'agnix': 'Lint agent configurations (399 rules)',
     'ship': 'PR creation, CI monitoring, merge',
     'deslop': 'Clean AI slop patterns',
     'perf': 'Performance investigation with baselines and profiling',

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -109,7 +109,8 @@ const STATIC_SKILLS = [
   { plugin: 'audit-project', name: 'audit-project' },
   { plugin: 'glidemq', name: 'glide-mq' },
   { plugin: 'glidemq', name: 'glide-mq-migrate-bullmq' },
-  { plugin: 'glidemq', name: 'glide-mq-migrate-bee' }
+  { plugin: 'glidemq', name: 'glide-mq-migrate-bee' },
+  { plugin: 'agnix', name: 'agnix' }
 ];
 
 // Purpose mapping for architecture table

--- a/site/content.json
+++ b/site/content.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "agentsys",
-    "description": "A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 40 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.",
+    "description": "A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 41 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.",
     "url": "https://agent-sh.github.io/agentsys",
     "repo": "https://github.com/agent-sh/agentsys",
     "npm": "https://www.npmjs.com/package/agentsys",

--- a/site/content.json
+++ b/site/content.json
@@ -33,7 +33,7 @@
       "suffix": ""
     },
     {
-      "value": "40",
+      "value": "41",
       "label": "Skills",
       "suffix": ""
     },

--- a/site/index.html
+++ b/site/index.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>AgentSys - Agent Runtime &amp; Orchestration System</title>
-  <meta name="description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 40 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
+  <meta name="description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 41 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
   <meta name="theme-color" content="#09090b">
 
   <!-- Open Graph -->
   <meta property="og:title" content="AgentSys">
-  <meta property="og:description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 40 skills.">
+  <meta property="og:description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 41 skills.">
   <meta property="og:image" content="https://agent-sh.github.io/agentsys/assets/logo.png">
   <meta property="og:url" content="https://agent-sh.github.io/agentsys/">
   <meta property="og:type" content="website">
@@ -17,7 +17,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="AgentSys">
-  <meta name="twitter:description" content="AI workflow automation. 19 plugins, 49 agents, 40 skills.">
+  <meta name="twitter:description" content="AI workflow automation. 19 plugins, 49 agents, 41 skills.">
   <meta name="twitter:image" content="https://agent-sh.github.io/agentsys/assets/logo.png">
 
   <!-- Content Security Policy -->
@@ -107,7 +107,7 @@
       <div class="hero__inner">
         <div class="hero__content">
           <div class="hero__badge anim-fade-in" data-delay="100">
-            19 plugins &middot; 49 agents &middot; 40 skills
+            19 plugins &middot; 49 agents &middot; 41 skills
           </div>
           <h1 class="hero__title anim-fade-up" id="hero-title" data-delay="200">
             A modular <span class="text-gradient">runtime and orchestration system</span><br>
@@ -164,7 +164,7 @@
           <span class="stats__label">Agents</span>
         </div>
         <div class="stats__item">
-          <span class="stats__number" aria-live="polite" data-target="40">0</span>
+          <span class="stats__number" aria-live="polite" data-target="41">0</span>
           <span class="stats__label">Skills</span>
         </div>
         <div class="stats__item">
@@ -662,7 +662,7 @@
     <!-- ===== AGENTS & SKILLS ===== -->
     <section class="agents-skills" id="agents-skills" aria-labelledby="as-title">
       <div class="agents-skills__inner">
-        <h2 class="agents-skills__title anim-fade-up" id="as-title">49 Agents. 40 Skills.</h2>
+        <h2 class="agents-skills__title anim-fade-up" id="as-title">49 Agents. 41 Skills.</h2>
         <p class="agents-skills__subtitle anim-fade-up" data-delay="100">Right model for the task. Opus reasons. Sonnet validates. Haiku executes.</p>
 
         <!-- Agent tier tabs -->
@@ -749,7 +749,7 @@
         </div>
 
         <!-- Skills grid -->
-        <h3 class="agents-skills__skills-title anim-fade-up" data-delay="300">40 Skills across 19 Plugins</h3>
+        <h3 class="agents-skills__skills-title anim-fade-up" data-delay="300">41 Skills across 19 Plugins</h3>
         <div class="skills-grid anim-fade-up" data-delay="350">
           <div class="skill-group">
             <span class="skill-group__label">prepare-delivery</span>

--- a/site/index.html
+++ b/site/index.html
@@ -821,6 +821,7 @@
               <span class="skill-card">onboard</span>
               <span class="skill-card">can-i-help</span>
               <span class="skill-card">audit-project</span>
+              <span class="skill-card">agnix</span>
             </div>
           </div>
           <div class="skill-group">

--- a/site/ux-spec.md
+++ b/site/ux-spec.md
@@ -94,7 +94,7 @@ Scroll order with rationale for each section. All sections are full-width, alter
 - **Single column on mobile:** Text above, terminal below. Stack with 48px gap.
 
 ### Left Column Content
-1. **Badge** (top, above title): Small pill showing version or "19 plugins . 49 agents . 40 skills"
+1. **Badge** (top, above title): Small pill showing version or "19 plugins . 49 agents . 41 skills"
    - Background: `rgba(99, 102, 241, 0.12)`, border: `1px solid rgba(99, 102, 241, 0.25)`, border-radius: 9999px
    - Font: 13px, font-weight 500, primary accent color
    - Padding: 4px 14px
@@ -104,7 +104,7 @@ Scroll order with rationale for each section. All sections are full-width, alter
    - Color: white
    - "entire dev workflow" portion highlighted with a subtle gradient text (primary-to-secondary accent via `background-clip: text`)
 
-3. **Subtitle:** "19 plugins, 49 agents, 40 skills. From task selection to merged PR. Works with Claude Code, OpenCode, Codex CLI, Cursor, and Kiro."
+3. **Subtitle:** "19 plugins, 49 agents, 41 skills. From task selection to merged PR. Works with Claude Code, OpenCode, Codex CLI, Cursor, and Kiro."
    - Font: 18px on desktop, 16px on mobile, font-weight 400, line-height 1.6
    - Color: `rgba(255, 255, 255, 0.6)`
    - Max-width: 520px
@@ -650,13 +650,13 @@ This disables:
 ### Head Content
 ```html
 <title>AgentSys - Agent Runtime &amp; Orchestration System</title>
-<meta name="description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 40 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
+<meta name="description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 41 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="theme-color" content="#0a0a0f">
 
 <!-- Open Graph -->
 <meta property="og:title" content="AgentSys">
-<meta property="og:description" content="AI workflow automation. 19 plugins, 49 agents, 40 skills. Task to merged PR.">
+<meta property="og:description" content="AI workflow automation. 19 plugins, 49 agents, 41 skills. Task to merged PR.">
 <meta property="og:image" content="https://agent-sh.github.io/agentsys/assets/og-image.png">
 <meta property="og:url" content="https://agent-sh.github.io/agentsys/">
 <meta property="og:type" content="website">
@@ -664,7 +664,7 @@ This disables:
 <!-- Twitter Card -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AgentSys">
-<meta name="twitter:description" content="AI workflow automation. 19 plugins, 49 agents, 40 skills.">
+<meta name="twitter:description" content="AI workflow automation. 19 plugins, 49 agents, 41 skills.">
 <meta name="twitter:image" content="https://agent-sh.github.io/agentsys/assets/og-image.png">
 ```
 


### PR DESCRIPTION
## Summary
- Add \`agnix\` to the README Skills category table (new \`Linting\` row)
- Add \`{ plugin: 'agnix', name: 'agnix' }\` to STATIC_SKILLS in generate-docs.js
- Bump 40 -> 41 in README, site/index.html (meta + hero + section title + data-target), site/content.json, site/ux-spec.md

## Why
The agnix plugin has had a real SKILL.md at \`skills/agnix/SKILL.md\` for a while but was missing from this repo's Skills enumeration. With agent-sh/audit-project#17 also adding the missing audit-project SKILL.md, the ecosystem now has 41 real, file-based skills.

## Test plan
- [x] \`npm test\` passes (3507)
- [x] \`gen-docs --check\` returns fresh after regeneration
- [x] STATIC_SKILLS.length === 41
- [x] All 41 references display same number across README/site/ux-spec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates plus a small docs-generator list change; low risk aside from keeping displayed skill counts consistent across surfaces.
> 
> **Overview**
> **Adds `agnix` as a first-class skill in the ecosystem docs.** The README skills table now includes a new *Linting* category with `agnix`, and the docs generation script (`scripts/generate-docs.js`) includes `agnix` in `STATIC_SKILLS` so generated sections stay in sync.
> 
> **Aligns displayed skill counts across surfaces.** Updates the skill total from **40 → 41** in README, `site/content.json`, `site/index.html` (meta/hero/stats/section headings), and `site/ux-spec.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beabf131aef28ea9fb75995bbda41eff9be438dd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->