### PR TITLE
fix(package): scope version script git staging to package.json only

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "bump": "node bin/dev-cli.js bump",
     "detect": "node bin/dev-cli.js detect",
     "verify": "node bin/dev-cli.js verify",
-    "version": "node scripts/stamp-version.js && git add -A",
+    "version": "node scripts/stamp-version.js && git add package.json package-lock.json .claude-plugin/plugin.json .claude-plugin/marketplace.json site/content.json",
     "setup-hooks": "node bin/dev-cli.js setup-hooks"
   },
   "repository": {


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Low)

`package.json` line 40: the `version` lifecycle script runs `git add -A` after stamping the version, which stages **all** working-tree changes — not just the version bump.

If a developer has unrelated uncommitted changes in their working tree at the time they run `npm version`, those changes will be silently included in the version bump commit. This can inadvertently publish in-progress work, debug code, or sensitive scratchpad content.

## Fix

Replace `git add -A` with `git add package.json` to stage only the file that was actually changed by the version stamp script.

If `scripts/stamp-version.js` also writes to other files (e.g., a `VERSION` file or changelog), those specific files should be added explicitly rather than using the catch-all `-A`.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->