### PR TITLE
fix(deps): pin js-yaml to exact version 4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "agentsys": "^5.0.0",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "4.1.1"
   },
   "devDependencies": {
     "jest": "^29.7.0"


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Low)

`package.json` line 85: `"js-yaml": "^4.1.1"` uses a caret range, which allows npm to automatically install any `4.x.y` version where `x >= 1`. While `js-yaml` is a well-maintained library with a strong security record, caret ranges create a class of supply-chain risk: a future `4.2.0` release (or a compromised one) would be installed automatically on `npm install` without any explicit upgrade decision.

## Fix

Pin `js-yaml` to the exact version `4.1.1` — which is already the resolved version in `package-lock.json`. This makes the dependency fully reproducible and ensures any future upgrade is an explicit, reviewable choice.

Note: `jest` in devDependencies is left as `^29.7.0` since devDependencies are not shipped to end users and the risk profile is lower. If reproducible dev environments are also a priority, that can be pinned separately.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->