### PR TITLE
fix(test): bump timeout on flaky ensureRepoMap async tests

### DIFF
--- a/__tests__/docs-patterns.test.js
+++ b/__tests__/docs-patterns.test.js
@@ -908,18 +908,22 @@ describe('docs-patterns', () => {
     });
 
     describe('ensureRepoMap (async)', () => {
+      // Async path can spawn ast-grep (checkAstGrepInstalled + init), which is
+      // slow to start on Windows. Default 5s jest timeout is too tight.
+      const ASYNC_TIMEOUT = 30_000;
+
       test('returns unavailable when repo-map not initialized', async () => {
         const result = await ensureRepoMap({ cwd: testDir });
         expect(result.available).toBe(false);
         expect(result.fallbackReason).toBeTruthy();
-      });
+      }, ASYNC_TIMEOUT);
 
       test('returns correct structure', async () => {
         const result = await ensureRepoMap({ cwd: testDir });
         expect(result).toHaveProperty('available');
         expect(result).toHaveProperty('map');
         expect(result).toHaveProperty('fallbackReason');
-      });
+      }, ASYNC_TIMEOUT);
 
       test('does not call askUser if repo-map module not found', async () => {
         const askUser = jest.fn();
@@ -927,7 +931,7 @@ describe('docs-patterns', () => {
         // askUser should not be called when module isn't available or no ast-grep
         // This depends on environment, but at minimum the structure should be correct
         expect(result).toHaveProperty('available');
-      });
+      }, ASYNC_TIMEOUT);
     });
 
     describe('findUndocumentedExports', () => {


### PR DESCRIPTION
## Summary

Three async tests in \`__tests__/docs-patterns.test.js\` (the \`ensureRepoMap (async)\` describe block) intermittently fail with jest's default 5s timeout:

\`\`\`
ensureRepoMap (async) > returns unavailable when repo-map not initialized
thrown: \"Exceeded timeout of 5000 ms for a test.\"
\`\`\`

Surfaced by the v5.8.5 release pre-push hook running \`npm test\` — the failure was non-deterministic (passed on fresh runs, failed on subsequent ones).

### Root cause

The async path calls \`repoMap.checkAstGrepInstalled()\` and potentially \`repoMap.init()\`. Both spawn the \`ast-grep\` binary externally. On Windows, process spawn is slow (1-3s each), so the cumulative external-binary work tips past 5s on slower runs.

### Fix

Set an explicit 30s timeout on the 3 async tests. Tolerates the legitimate ast-grep spawn variability without masking real hangs. Sync siblings (\`ensureRepoMapSync\`) don't need the bump - they don't spawn anything.

## Test plan

- [x] 3 consecutive runs of \`__tests__/docs-patterns.test.js\` pass cleanly (~12s each)
- [ ] CI green