### PR TITLE
chore: release v5.8.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "agentsys",
   "description": "19 specialized plugins for AI workflow automation - task orchestration, PR workflow, slop detection, code review, drift detection, enhancement analysis, documentation sync, unified static analysis, perf investigations, topic research, agent config linting, cross-tool AI consultation, structured AI debate, workflow pattern learning, codebase onboarding, and contributor guidance",
-  "version": "5.8.5",
+  "version": "5.8.6",
   "owner": {
     "name": "Avi Fenesh",
     "url": "https://github.com/avifenesh"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "version": "5.8.5",
+  "version": "5.8.6",
   "description": "Professional-grade slash commands for Claude Code with cross-platform support",
   "keywords": [
     "workflow",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.8.6] - 2026-04-23
+
+### Added
+- **`@agentsys/lib`'s `repoIntel.queries` module** - typed wrappers over every `agent-analyzer repo-intel query <type>` subcommand (28 functions). Consumer plugins can now call `require('@agentsys/lib').repoIntel.queries.hotspots(cwd, { limit: 20 })` instead of constructing raw CLI argv themselves. Functions returned in JSON match the binary's output shape per query.
+- **4 new graph-derived query wrappers** for the analyzer-graph crate landed in agent-analyzer v0.4.0:
+  - `communities(cwd)` - lists Louvain-discovered file clusters (the natural feature areas, independent of directory layout)
+  - `boundaries(cwd, { limit })` - files bridging multiple communities by betweenness centrality (architectural seams - highest-leverage files for refactoring)
+  - `areaOf(cwd, file)` - which community a file belongs to
+  - `communityHealth(cwd, id)` - composite per-community roll-up (size, total/recent changes, bug-fix rate, AI ratio, stale-owner count)
+
+### Changed
+- **`ANALYZER_MIN_VERSION` bumped 0.3.0 -> 0.4.0** to match agent-analyzer v0.4.0 which adds the graph subcommands. Older binaries get auto-upgraded on first call by `lib/binary.ensureBinary()`.
+
 ## [5.8.5] - 2026-04-23
 
 ### Fixed

--- a/__tests__/repo-intel-queries.test.js
+++ b/__tests__/repo-intel-queries.test.js
@@ -1,0 +1,245 @@
+/**
+ * Tests for lib/repo-intel/queries - typed wrappers over agent-analyzer
+ * `repo-intel query <type>` subcommands.
+ *
+ * Verifies argv construction (the contract with the binary), error wrapping
+ * (parse failures, missing artifact), and input validation. The binary
+ * itself is mocked so these run hermetically in CI.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Mock the binary module so runAnalyzer doesn't actually shell out.
+jest.mock('../lib/binary', () => ({
+  runAnalyzer: jest.fn(),
+}));
+
+const binary = require('../lib/binary');
+const queries = require('../lib/repo-intel/queries');
+
+describe('lib/repo-intel/queries', () => {
+  let tempDir;
+  let mapFilePath;
+
+  beforeEach(() => {
+    binary.runAnalyzer.mockReset();
+    // Build a fake repo with the state dir + map file the queries look for.
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-intel-queries-test-'));
+    fs.mkdirSync(path.join(tempDir, '.claude'), { recursive: true });
+    mapFilePath = path.join(tempDir, '.claude', 'repo-intel.json');
+    fs.writeFileSync(mapFilePath, '{}');
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  // ─── Argv construction ────────────────────────────────────────────────────
+  // For each query, we mock the binary to return a known JSON value, call
+  // the wrapper, then assert the exact argv passed through. This is the
+  // load-bearing contract with the agent-analyzer CLI.
+
+  describe('argv construction', () => {
+    test('hotspots without limit', () => {
+      binary.runAnalyzer.mockReturnValue('[]');
+      queries.hotspots(tempDir);
+      const args = binary.runAnalyzer.mock.calls[0][0];
+      expect(args.slice(0, 3)).toEqual(['repo-intel', 'query', 'hotspots']);
+      expect(args).toContain('--map-file');
+      expect(args).toContain(mapFilePath);
+      expect(args).toContain(tempDir);
+      expect(args).not.toContain('--top');
+    });
+
+    test('hotspots with limit adds --top', () => {
+      binary.runAnalyzer.mockReturnValue('[]');
+      queries.hotspots(tempDir, { limit: 25 });
+      const args = binary.runAnalyzer.mock.calls[0][0];
+      expect(args).toContain('--top');
+      expect(args[args.indexOf('--top') + 1]).toBe('25');
+    });
+
+    test('coupling forwards file argument', () => {
+      binary.runAnalyzer.mockReturnValue('[]');
+      queries.coupling(tempDir, 'src/auth.js');
+      const args = binary.runAnalyzer.mock.calls[0][0];
+      expect(args.slice(0, 4)).toEqual(['repo-intel', 'query', 'coupling', 'src/auth.js']);
+    });
+
+    test('busFactor with adjustForAi adds --adjust-for-ai', () => {
+      binary.runAnalyzer.mockReturnValue('{}');
+      queries.busFactor(tempDir, { adjustForAi: true });
+      const args = binary.runAnalyzer.mock.calls[0][0];
+      expect(args).toContain('--adjust-for-ai');
+    });
+
+    test('testGaps with limit + minChanges adds both flags', () => {
+      binary.runAnalyzer.mockReturnValue('[]');
+      queries.testGaps(tempDir, { limit: 5, minChanges: 3 });
+      const args = binary.runAnalyzer.mock.calls[0][0];
+      expect(args[args.indexOf('--top') + 1]).toBe('5');
+      expect(args[args.indexOf('--min-changes') + 1]).toBe('3');
+    });
+
+    test('aiRatio with pathFilter adds --path-filter', () => {
+      binary.runAnalyzer.mockReturnValue('{}');
+      queries.aiRatio(tempDir, { pathFilter: 'src/' });
+      const args = binary.runAnalyzer.mock.calls[0][0];
+      expect(args[args.indexOf('--path-filter') + 1]).toBe('src/');
+    });
+
+    test('diffRisk joins files with comma', () => {
+      binary.runAnalyzer.mockReturnValue('[]');
+      queries.diffRisk(tempDir, ['a.js', 'b.js', 'c.js']);
+      const args = binary.runAnalyzer.mock.calls[0][0];
+      expect(args[args.indexOf('--files') + 1]).toBe('a.js,b.js,c.js');
+    });
+
+    test('dependents with file scope adds --file', () => {
+      binary.runAnalyzer.mockReturnValue('{}');
+      queries.dependents(tempDir, 'createUser', 'src/users.js');
+      const args = binary.runAnalyzer.mock.calls[0][0];
+      expect(args).toContain('createUser');
+      expect(args[args.indexOf('--file') + 1]).toBe('src/users.js');
+    });
+  });
+
+  // ─── Phase 5 graph queries ────────────────────────────────────────────────
+
+  describe('graph queries (Phase 5.1)', () => {
+    test('communities sends "communities" subcommand', () => {
+      binary.runAnalyzer.mockReturnValue('[]');
+      queries.communities(tempDir);
+      const args = binary.runAnalyzer.mock.calls[0][0];
+      expect(args.slice(0, 3)).toEqual(['repo-intel', 'query', 'communities']);
+    });
+
+    test('boundaries with limit adds --top', () => {
+      binary.runAnalyzer.mockReturnValue('[]');
+      queries.boundaries(tempDir, { limit: 8 });
+      const args = binary.runAnalyzer.mock.calls[0][0];
+      expect(args.slice(0, 3)).toEqual(['repo-intel', 'query', 'boundaries']);
+      expect(args[args.indexOf('--top') + 1]).toBe('8');
+    });
+
+    test('areaOf forwards file argument', () => {
+      binary.runAnalyzer.mockReturnValue('{}');
+      queries.areaOf(tempDir, 'src/foo.js');
+      const args = binary.runAnalyzer.mock.calls[0][0];
+      expect(args.slice(0, 4)).toEqual(['repo-intel', 'query', 'area-of', 'src/foo.js']);
+    });
+
+    test('communityHealth forwards id as string', () => {
+      binary.runAnalyzer.mockReturnValue('{}');
+      queries.communityHealth(tempDir, 7);
+      const args = binary.runAnalyzer.mock.calls[0][0];
+      expect(args.slice(0, 4)).toEqual(['repo-intel', 'query', 'community-health', '7']);
+    });
+  });
+
+  // ─── Input validation ─────────────────────────────────────────────────────
+
+  describe('input validation', () => {
+    test('communityHealth rejects non-integer id', () => {
+      expect(() => queries.communityHealth(tempDir, 'foo')).toThrow(TypeError);
+      expect(() => queries.communityHealth(tempDir, null)).toThrow(TypeError);
+      expect(() => queries.communityHealth(tempDir, 1.5)).toThrow(TypeError);
+      expect(() => queries.communityHealth(tempDir, -1)).toThrow(TypeError);
+      expect(binary.runAnalyzer).not.toHaveBeenCalled();
+    });
+
+    test('diffRisk rejects non-array files', () => {
+      expect(() => queries.diffRisk(tempDir, 'a.js')).toThrow(TypeError);
+      expect(() => queries.diffRisk(tempDir, [1, 2, 3])).toThrow(TypeError);
+      expect(binary.runAnalyzer).not.toHaveBeenCalled();
+    });
+
+    test('diffRisk rejects oversized file argument', () => {
+      // 1000 paths × 50 chars each = 50000 chars, exceeds 30000 cap.
+      const huge = Array.from({ length: 1000 }, (_, i) => `path/that/is/about/fifty-chars-long/file${i}.js`);
+      expect(() => queries.diffRisk(tempDir, huge)).toThrow(RangeError);
+      expect(binary.runAnalyzer).not.toHaveBeenCalled();
+    });
+
+    test('diffRisk accepts a normal-sized file argument', () => {
+      binary.runAnalyzer.mockReturnValue('[]');
+      queries.diffRisk(tempDir, ['a.js', 'b.js']);
+      expect(binary.runAnalyzer).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─── Error wrapping ───────────────────────────────────────────────────────
+
+  describe('error wrapping', () => {
+    test('throws RepoIntelMissingError when artifact is absent', () => {
+      // Use a fresh dir with no .claude/repo-intel.json.
+      const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-intel-empty-'));
+      try {
+        let caught;
+        try {
+          queries.hotspots(emptyDir);
+        } catch (err) {
+          caught = err;
+        }
+        expect(caught).toBeInstanceOf(queries.RepoIntelMissingError);
+        expect(caught.code).toBe('REPO_INTEL_MISSING');
+        expect(caught.mapFile).toContain('repo-intel.json');
+        expect(binary.runAnalyzer).not.toHaveBeenCalled();
+      } finally {
+        fs.rmSync(emptyDir, { recursive: true, force: true });
+      }
+    });
+
+    test('wraps binary failure with query context', () => {
+      binary.runAnalyzer.mockImplementation(() => {
+        throw new Error('binary blew up');
+      });
+      let caught;
+      try {
+        queries.bugspots(tempDir, { limit: 5 });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect(caught.message).toContain('repo-intel query failed');
+      expect(caught.message).toContain('bugspots');
+      expect(caught.message).toContain('binary blew up');
+      expect(caught.cause).toBeDefined();
+    });
+
+    test('wraps non-JSON output with preview', () => {
+      binary.runAnalyzer.mockReturnValue('not actually json');
+      let caught;
+      try {
+        queries.health(tempDir);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect(caught.message).toContain('non-JSON output');
+      expect(caught.message).toContain('health');
+      expect(caught.message).toContain('not actually json');
+    });
+
+    test('non-JSON output preview is truncated', () => {
+      // 500 chars - should be truncated to 200 in the message.
+      const big = 'x'.repeat(500);
+      binary.runAnalyzer.mockReturnValue(big);
+      let caught;
+      try {
+        queries.health(tempDir);
+      } catch (err) {
+        caught = err;
+      }
+      // The message contains exactly 200 x's, not 500.
+      const xCount = (caught.message.match(/x/g) || []).length;
+      expect(xCount).toBe(200);
+    });
+  });
+});

--- a/lib/binary/version.js
+++ b/lib/binary/version.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Minimum binary version required by this version of agent-core
-const ANALYZER_MIN_VERSION = '0.3.0';
+const ANALYZER_MIN_VERSION = '0.4.0';
 
 // Binary name
 const BINARY_NAME = 'agent-analyzer';

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,6 +30,7 @@ const perf = require('./perf');
 const collectors = require('./collectors');
 const discoveryModule = require('./discovery');
 const binary = require('./binary');
+const repoIntel = require('./repo-intel');
 
 /**
  * Platform detection and verification utilities
@@ -255,6 +256,7 @@ module.exports = {
   collectors,
   discovery,
   binary,
+  repoIntel,
 
   // Direct module access for backward compatibility
   detectPlatform,

--- a/lib/package.json
+++ b/lib/package.json
@@ -13,6 +13,8 @@
     "./discovery": "./discovery/index.js",
     "./enhance": "./enhance/index.js",
     "./perf": "./perf/index.js",
+    "./repo-intel": "./repo-intel/index.js",
+    "./repo-intel/queries": "./repo-intel/queries.js",
     "./repo-map": "./repo-map/index.js",
     "./collectors/codebase": "./collectors/codebase.js",
     "./collectors/docs-patterns": "./collectors/docs-patterns.js",

--- a/lib/repo-intel/index.js
+++ b/lib/repo-intel/index.js
@@ -1,0 +1,21 @@
+/**
+ * Repo intel module - typed wrappers over agent-analyzer's repo-intel
+ * subcommands. Consumers can import via:
+ *
+ *   const { repoIntel } = require('@agentsys/lib');
+ *   const hot = repoIntel.queries.hotspots(cwd, { limit: 20 });
+ *   const communities = repoIntel.queries.communities(cwd);
+ *
+ * The Rust binary is downloaded lazily on first call by lib/binary; this
+ * module just constructs the right argv and parses the JSON output.
+ *
+ * @module lib/repo-intel
+ */
+
+'use strict';
+
+const queries = require('./queries');
+
+module.exports = {
+  queries,
+};

--- a/lib/repo-intel/queries.js
+++ b/lib/repo-intel/queries.js
@@ -1,0 +1,367 @@
+/**
+ * Repo intel query functions
+ *
+ * Typed wrappers over `agent-analyzer repo-intel query <type>` subcommands.
+ * Consumer plugins can call these instead of constructing CLI args by hand:
+ *
+ *   const { repoIntel } = require('@agentsys/lib');
+ *   const hot = repoIntel.queries.hotspots(cwd, { limit: 20 });
+ *
+ * Each function resolves the cached `repo-intel.json` via the platform
+ * state-dir helper and shells out to the binary downloaded by lib/binary.
+ *
+ * @module lib/repo-intel/queries
+ */
+
+'use strict';
+
+const path = require('path');
+const binary = require('../binary');
+const { getStateDirPath } = require('../platform/state-dir');
+
+const MAP_FILENAME = 'repo-intel.json';
+
+/**
+ * Absolute path to the cached repo-intel artifact for `basePath`.
+ *
+ * @param {string} basePath
+ * @returns {string}
+ */
+function mapFilePath(basePath) {
+  return path.join(getStateDirPath(basePath), MAP_FILENAME);
+}
+
+/**
+ * Run a binary query and return the parsed JSON result.
+ *
+ * @param {string} basePath - Repository root
+ * @param {string[]} queryArgs - Arguments after `repo-intel query`
+ * @returns {Object|Array} Parsed query result
+ */
+function runQuery(basePath, queryArgs) {
+  const args = ['repo-intel', 'query', ...queryArgs, '--map-file', mapFilePath(basePath), basePath];
+  const output = binary.runAnalyzer(args);
+  return JSON.parse(output);
+}
+
+// ─── Activity ───────────────────────────────────────────────────────────────
+
+/**
+ * Return files sorted by recency-weighted change score.
+ *
+ * @param {string} basePath
+ * @param {Object} [options={}]
+ * @param {number} [options.limit] - Maximum number of results
+ */
+function hotspots(basePath, options = {}) {
+  const args = ['hotspots'];
+  if (options.limit) args.push('--top', String(options.limit));
+  return runQuery(basePath, args);
+}
+
+/**
+ * Return least-changed files (no recent activity).
+ */
+function coldspots(basePath, options = {}) {
+  const args = ['coldspots'];
+  if (options.limit) args.push('--top', String(options.limit));
+  return runQuery(basePath, args);
+}
+
+/**
+ * Return change history for a specific file.
+ */
+function fileHistory(basePath, file) {
+  return runQuery(basePath, ['file-history', file]);
+}
+
+// ─── Quality ────────────────────────────────────────────────────────────────
+
+/**
+ * Return files with highest bug-fix density.
+ */
+function bugspots(basePath, options = {}) {
+  const args = ['bugspots'];
+  if (options.limit) args.push('--top', String(options.limit));
+  return runQuery(basePath, args);
+}
+
+/**
+ * Return hot source files with no co-changing test file.
+ */
+function testGaps(basePath, options = {}) {
+  const args = ['test-gaps'];
+  if (options.limit) args.push('--top', String(options.limit));
+  if (options.minChanges) args.push('--min-changes', String(options.minChanges));
+  return runQuery(basePath, args);
+}
+
+/**
+ * Score changed files by composite risk.
+ *
+ * @param {string} basePath
+ * @param {string[]} files - List of changed file paths
+ */
+function diffRisk(basePath, files) {
+  return runQuery(basePath, ['diff-risk', '--files', files.join(',')]);
+}
+
+/**
+ * Files ranked by hotspot × (1 + bug_rate) × (1 + complexity/30). Requires
+ * Phase 2 AST data; falls back to git-only when unavailable.
+ */
+function painspots(basePath, options = {}) {
+  const args = ['painspots'];
+  if (options.limit) args.push('--top', String(options.limit));
+  return runQuery(basePath, args);
+}
+
+// ─── People ─────────────────────────────────────────────────────────────────
+
+/**
+ * Return ownership breakdown for a file or directory.
+ */
+function ownership(basePath, file) {
+  return runQuery(basePath, ['ownership', file]);
+}
+
+/**
+ * Return contributors sorted by commit count.
+ */
+function contributors(basePath, options = {}) {
+  const args = ['contributors'];
+  if (options.limit) args.push('--top', String(options.limit));
+  return runQuery(basePath, args);
+}
+
+/**
+ * Detailed bus factor with critical owners and at-risk areas.
+ */
+function busFactor(basePath, options = {}) {
+  const args = ['bus-factor'];
+  if (options.adjustForAi) args.push('--adjust-for-ai');
+  return runQuery(basePath, args);
+}
+
+// ─── Coupling ───────────────────────────────────────────────────────────────
+
+/**
+ * Files that frequently change together with `file`.
+ */
+function coupling(basePath, file) {
+  return runQuery(basePath, ['coupling', file]);
+}
+
+// ─── Standards ──────────────────────────────────────────────────────────────
+
+/**
+ * Project norms (commit conventions, etc.) detected from git history.
+ */
+function norms(basePath) {
+  return runQuery(basePath, ['norms']);
+}
+
+/**
+ * Commit message style + prefixes + scope usage.
+ */
+function conventions(basePath) {
+  return runQuery(basePath, ['conventions']);
+}
+
+// ─── Health ─────────────────────────────────────────────────────────────────
+
+/**
+ * Directory-level health overview.
+ */
+function areas(basePath) {
+  return runQuery(basePath, ['areas']);
+}
+
+/**
+ * Repository-wide health summary.
+ */
+function health(basePath) {
+  return runQuery(basePath, ['health']);
+}
+
+/**
+ * Release cadence and tag history.
+ */
+function releaseInfo(basePath) {
+  return runQuery(basePath, ['release-info']);
+}
+
+// ─── AI detection ───────────────────────────────────────────────────────────
+
+/**
+ * AI vs human contribution ratio.
+ */
+function aiRatio(basePath, options = {}) {
+  const args = ['ai-ratio'];
+  if (options.pathFilter) args.push('--path-filter', options.pathFilter);
+  return runQuery(basePath, args);
+}
+
+/**
+ * Files with recent AI-authored changes.
+ */
+function recentAi(basePath, options = {}) {
+  const args = ['recent-ai'];
+  if (options.limit) args.push('--top', String(options.limit));
+  return runQuery(basePath, args);
+}
+
+// ─── Contributor guidance ───────────────────────────────────────────────────
+
+/**
+ * Newcomer-oriented repo summary (tech stack, key areas, pain points).
+ */
+function onboard(basePath) {
+  return runQuery(basePath, ['onboard']);
+}
+
+/**
+ * Contribution guidance: good-first areas, test gaps, doc drift, bugspots.
+ */
+function canIHelp(basePath) {
+  return runQuery(basePath, ['can-i-help']);
+}
+
+// ─── Documentation ──────────────────────────────────────────────────────────
+
+/**
+ * Doc files with low code coupling (likely stale).
+ */
+function docDrift(basePath, options = {}) {
+  const args = ['doc-drift'];
+  if (options.limit) args.push('--top', String(options.limit));
+  return runQuery(basePath, args);
+}
+
+/**
+ * Doc files with stale references to source symbols. Requires Phase 4
+ * sync-check data.
+ */
+function staleDocs(basePath, options = {}) {
+  const args = ['stale-docs'];
+  if (options.limit) args.push('--top', String(options.limit));
+  return runQuery(basePath, args);
+}
+
+// ─── AST symbols ────────────────────────────────────────────────────────────
+
+/**
+ * AST symbols (exports, imports, definitions) for a specific file. Requires
+ * Phase 2 AST data.
+ */
+function symbols(basePath, file) {
+  return runQuery(basePath, ['symbols', file]);
+}
+
+/**
+ * Files that import a given symbol (reverse dependency lookup). Requires
+ * Phase 2 AST data.
+ */
+function dependents(basePath, symbol, file) {
+  const args = ['dependents', symbol];
+  if (file) args.push('--file', file);
+  return runQuery(basePath, args);
+}
+
+// ─── Phase 5: Graph-derived (analyzer-graph crate) ──────────────────────────
+
+/**
+ * Communities discovered by Louvain modularity over the co-change graph.
+ * Returns clusters of files that consistently change together - the natural
+ * feature areas, independent of directory layout. Requires agent-analyzer
+ * v0.4.0+.
+ *
+ * @param {string} basePath
+ * @returns {Array<{id: number, size: number, files: string[]}>}
+ */
+function communities(basePath) {
+  return runQuery(basePath, ['communities']);
+}
+
+/**
+ * Files bridging multiple communities (high betweenness centrality). These
+ * are the architectural seams - the highest-leverage files for refactoring
+ * decisions. Requires agent-analyzer v0.4.0+.
+ *
+ * @param {string} basePath
+ * @param {Object} [options={}]
+ * @param {number} [options.limit] - Maximum number of results
+ * @returns {Array<{path: string, betweenness: number, community: number|null}>}
+ */
+function boundaries(basePath, options = {}) {
+  const args = ['boundaries'];
+  if (options.limit) args.push('--top', String(options.limit));
+  return runQuery(basePath, args);
+}
+
+/**
+ * Look up which community a given file belongs to. Requires agent-analyzer
+ * v0.4.0+.
+ *
+ * @param {string} basePath
+ * @param {string} file - File path (relative to repo root)
+ * @returns {{file: string, community: number|null, size: number|null}}
+ */
+function areaOf(basePath, file) {
+  return runQuery(basePath, ['area-of', file]);
+}
+
+/**
+ * Composite per-community health: total/recent changes, bug-fix rate,
+ * AI ratio, stale-owner count. Use to identify communities under stress
+ * (high bug rate or stale ownership). Requires agent-analyzer v0.4.0+.
+ *
+ * @param {string} basePath
+ * @param {number} id - Community id (from `communities()`)
+ * @returns {Object|null}
+ */
+function communityHealth(basePath, id) {
+  return runQuery(basePath, ['community-health', String(id)]);
+}
+
+module.exports = {
+  // Activity
+  hotspots,
+  coldspots,
+  fileHistory,
+  // Quality
+  bugspots,
+  testGaps,
+  diffRisk,
+  painspots,
+  // People
+  ownership,
+  contributors,
+  busFactor,
+  // Coupling
+  coupling,
+  // Standards
+  norms,
+  conventions,
+  // Health
+  areas,
+  health,
+  releaseInfo,
+  // AI detection
+  aiRatio,
+  recentAi,
+  // Contributor guidance
+  onboard,
+  canIHelp,
+  // Documentation
+  docDrift,
+  staleDocs,
+  // AST symbols
+  symbols,
+  dependents,
+  // Phase 5: graph-derived
+  communities,
+  boundaries,
+  areaOf,
+  communityHealth,
+};

--- a/lib/repo-intel/queries.js
+++ b/lib/repo-intel/queries.js
@@ -15,11 +15,19 @@
 
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 const binary = require('../binary');
 const { getStateDirPath } = require('../platform/state-dir');
 
 const MAP_FILENAME = 'repo-intel.json';
+
+// Conservative bound on a single CLI argument length. Windows cmd-line max
+// is ~32 KB total; modern Linux/macOS typically allow ~128 KB. We throw an
+// actionable error rather than letting `execFileSync` fail with a cryptic
+// E2BIG/ENAMETOOLONG, which would otherwise look like a binary crash to
+// the caller.
+const MAX_FILES_ARG_LEN = 30000;
 
 /**
  * Absolute path to the cached repo-intel artifact for `basePath`.
@@ -32,16 +40,68 @@ function mapFilePath(basePath) {
 }
 
 /**
+ * Error thrown when the cached repo-intel artifact is missing.
+ * Distinguished by a `.code = 'REPO_INTEL_MISSING'` field so callers can
+ * choose between auto-init, fallback, or surfacing the message.
+ */
+class RepoIntelMissingError extends Error {
+  constructor(mapFile) {
+    super(
+      `repo-intel artifact not found at ${mapFile}. Run ` +
+        '`agent-analyzer repo-intel init <path>` (or `/repo-intel init` ' +
+        'in a CC plugin) first to create it.'
+    );
+    this.name = 'RepoIntelMissingError';
+    this.code = 'REPO_INTEL_MISSING';
+    this.mapFile = mapFile;
+  }
+}
+
+/**
  * Run a binary query and return the parsed JSON result.
  *
  * @param {string} basePath - Repository root
  * @param {string[]} queryArgs - Arguments after `repo-intel query`
  * @returns {Object|Array} Parsed query result
+ * @throws {RepoIntelMissingError} If the cached artifact is missing.
+ * @throws {Error} If the binary fails or returns non-JSON output (with
+ *   the failing query and an output preview included in the message).
  */
 function runQuery(basePath, queryArgs) {
-  const args = ['repo-intel', 'query', ...queryArgs, '--map-file', mapFilePath(basePath), basePath];
-  const output = binary.runAnalyzer(args);
-  return JSON.parse(output);
+  const mapFile = mapFilePath(basePath);
+
+  // Surface a clear "run init first" message instead of letting the binary
+  // exit non-zero with a low-level "no such file" error that would bubble
+  // up unannotated through `binary.runAnalyzer`.
+  if (!fs.existsSync(mapFile)) {
+    throw new RepoIntelMissingError(mapFile);
+  }
+
+  const args = ['repo-intel', 'query', ...queryArgs, '--map-file', mapFile, basePath];
+
+  let output;
+  try {
+    output = binary.runAnalyzer(args);
+  } catch (err) {
+    // Wrap so the caller learns which query failed without having to dig
+    // through the CLI argv. The original error stays as `cause`.
+    const wrapped = new Error(
+      `repo-intel query failed (${queryArgs.join(' ')}): ${err.message}`
+    );
+    wrapped.cause = err;
+    throw wrapped;
+  }
+
+  try {
+    return JSON.parse(output);
+  } catch (err) {
+    const preview = output && output.length > 0 ? output.slice(0, 200) : '<empty>';
+    const wrapped = new Error(
+      `repo-intel query returned non-JSON output (${queryArgs.join(' ')}): ${preview}`
+    );
+    wrapped.cause = err;
+    throw wrapped;
+  }
 }
 
 // ─── Activity ───────────────────────────────────────────────────────────────
@@ -99,11 +159,28 @@ function testGaps(basePath, options = {}) {
 /**
  * Score changed files by composite risk.
  *
+ * Validates the joined file argument fits within the platform's argv length
+ * cap before shelling out (Windows is the tight constraint at ~32 KB).
+ * Callers with very large diffs should batch.
+ *
  * @param {string} basePath
  * @param {string[]} files - List of changed file paths
+ * @throws {TypeError} If `files` is not an array of strings.
+ * @throws {RangeError} If the joined argument exceeds {@link MAX_FILES_ARG_LEN}.
  */
 function diffRisk(basePath, files) {
-  return runQuery(basePath, ['diff-risk', '--files', files.join(',')]);
+  if (!Array.isArray(files) || !files.every((f) => typeof f === 'string')) {
+    throw new TypeError('diffRisk: `files` must be an array of strings');
+  }
+  const joined = files.join(',');
+  if (joined.length > MAX_FILES_ARG_LEN) {
+    throw new RangeError(
+      `diffRisk: joined file argument is ${joined.length} chars, ` +
+        `exceeds platform-safe limit of ${MAX_FILES_ARG_LEN}. ` +
+        `Split the request into batches (~500 paths each is typically safe).`
+    );
+  }
+  return runQuery(basePath, ['diff-risk', '--files', joined]);
 }
 
 /**
@@ -321,10 +398,17 @@ function areaOf(basePath, file) {
  * @returns {Object|null}
  */
 function communityHealth(basePath, id) {
+  if (!Number.isInteger(id) || id < 0) {
+    throw new TypeError(
+      `communityHealth: \`id\` must be a non-negative integer, got: ${id} (${typeof id})`
+    );
+  }
   return runQuery(basePath, ['community-health', String(id)]);
 }
 
 module.exports = {
+  // Errors
+  RepoIntelMissingError,
   // Activity
   hotspots,
   coldspots,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentsys",
-  "version": "5.8.5",
+  "version": "5.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentsys",
-      "version": "5.8.5",
+      "version": "5.8.6",
       "license": "MIT",
       "workspaces": [
         "lib"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "version": "5.8.5",
+  "version": "5.8.6",
   "description": "A modular runtime and orchestration system for AI agents - works with Claude Code, OpenCode, and Codex CLI",
   "main": "lib/platform/detect-platform.js",
   "type": "commonjs",

--- a/site/content.json
+++ b/site/content.json
@@ -5,7 +5,7 @@
     "url": "https://agent-sh.github.io/agentsys",
     "repo": "https://github.com/agent-sh/agentsys",
     "npm": "https://www.npmjs.com/package/agentsys",
-    "version": "5.8.5",
+    "version": "5.8.6",
     "author": "Avi Fenesh",
     "author_url": "https://github.com/avifenesh"
   },


### PR DESCRIPTION
## Summary

Adds typed query wrappers for repo-intel + the 4 new graph queries from agent-analyzer v0.4.0. Bumps `ANALYZER_MIN_VERSION` so the new binary auto-downloads on next call.

### Highlights

**Added**
- **`require('@agentsys/lib').repoIntel.queries`** - typed module covering all 28 `repo-intel query` subcommands. Consumer plugins can now call `repoIntel.queries.hotspots(cwd, { limit: 20 })` instead of constructing raw CLI argv. Removes one source of duplication across the 7 plugins that currently call `binary.runAnalyzer(['repo-intel', 'query', ...])` by hand.
- **4 graph query wrappers** for the new analyzer-graph crate (Phase 5.1):
  - `communities(cwd)` - Louvain-discovered file clusters
  - `boundaries(cwd, { limit })` - high-betweenness "seam" files
  - `areaOf(cwd, file)` - which community a file belongs to
  - `communityHealth(cwd, id)` - composite per-cluster roll-up (bug rate, AI ratio, stale owners)

**Changed**
- `ANALYZER_MIN_VERSION` 0.3.0 -> 0.4.0 - matches agent-analyzer v0.4.0 (just released). Older binaries auto-upgrade on first call.

### Files touched
- `package.json` (5.8.5 -> 5.8.6) + `package-lock.json`
- `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `site/content.json`
- `lib/repo-intel/queries.js` (new, 28 typed wrappers)
- `lib/repo-intel/index.js` (new module entry)
- `lib/index.js` (export `repoIntel`)
- `lib/binary/version.js` (min version bump)
- `CHANGELOG.md`

## Test plan

- [x] `node -e "require('./lib').repoIntel.queries"` exposes 28 functions including all 4 graph queries
- [x] Module loads cleanly (no circular deps)
- [x] No new code in patterns/agents/skills - additive lib only
- [x] All version manifests stamped via `npm version 5.8.6`
- [ ] CI green
- [ ] After merge: tag `v5.8.6` -> release.yml publishes to npm + creates GitHub release

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: adds a new public `repoIntel.queries` API that shells out to `agent-analyzer` and parses JSON, and bumps the required analyzer binary to v0.4.0 which will trigger auto-download/upgrade on use.
> 
> **Overview**
> Adds a new `repoIntel.queries` module in `@agentsys/lib` that wraps `agent-analyzer repo-intel query <type>` in typed helper functions (including new graph queries: `communities`, `boundaries`, `areaOf`, `communityHealth`) and exports it from `lib/index.js`.
> 
> Bumps `ANALYZER_MIN_VERSION` from `0.3.0` to `0.4.0` so older `agent-analyzer` binaries auto-upgrade on first run, and increments release/version stamps to `5.8.6` across manifests and `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ded76b176b64d0fbaecb9aa987e27b25953dae96. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->