### PR TITLE
feat: register zig-lsp plugin in agentsys marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "description": "19 specialized plugins for AI workflow automation - task orchestration, PR workflow, slop detection, code review, drift detection, enhancement analysis, documentation sync, unified static analysis, perf investigations, topic research, agent config linting, cross-tool AI consultation, structured AI debate, workflow pattern learning, codebase onboarding, and contributor guidance",
+  "description": "20 specialized plugins for AI workflow automation - task orchestration, PR workflow, slop detection, code review, drift detection, enhancement analysis, documentation sync, unified static analysis, perf investigations, topic research, agent config linting, cross-tool AI consultation, structured AI debate, workflow pattern learning, codebase onboarding, contributor guidance, and Zig language support",
   "version": "5.8.6",
   "owner": {
     "name": "Avi Fenesh",
@@ -230,6 +230,17 @@
       "version": "0.1.0",
       "category": "productivity",
       "homepage": "https://github.com/agent-sh/can-i-help"
+    },
+    {
+      "name": "zig-lsp",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/agent-sh/zig-lsp.git"
+      },
+      "description": "Zig language server for Claude Code via ZLS - automatic diagnostics after every edit, jump-to-definition, find-references, and hover. Requires zls in PATH",
+      "version": "0.1.0",
+      "category": "development",
+      "homepage": "https://github.com/agent-sh/zig-lsp"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@ agentsys                # Run installer
 <agents>
 ## Agents
 
-47 agents across 20 plugins (zig-lsp ships as a config-only LSP plugin with no agents). Key agents by model:
+49 agents across 20 plugins (18 have agents; gate-and-ship is commands-only; zig-lsp is config-only with no commands or agents). Key agents by model:
 
 | Model | Agents | Use Case |
 |-------|--------|----------|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@ agentsys                # Run installer
 <agents>
 ## Agents
 
-47 agents across 19 plugins. Key agents by model:
+47 agents across 20 plugins (zig-lsp ships as a config-only LSP plugin with no agents). Key agents by model:
 
 | Model | Agents | Use Case |
 |-------|--------|----------|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`zig-lsp` plugin** - Zig language server (ZLS) integration for Claude Code's `LSP` tool. Maps `.zig` and `.zon` to language `zig`; enables `enable_build_on_save` so post-edit diagnostics surface real type errors (not just parser errors); 30 s startup timeout, restart-on-crash with cap. Plugin is config-only - no slash commands, no agents, no skills - the harness's built-in `LSP` tool dispatches automatically once `zls` is on `PATH`. Marketplace entry under category `development`. Source: https://github.com/agent-sh/zig-lsp
+- Marketplace plugin count 19 -> 20 in `.claude-plugin/marketplace.json` description, `scripts/plugins.txt`, and `site/content.json` stats.
+
 ## [5.8.6] - 2026-04-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <b>19 plugins · 49 agents · 41 skills (across all repos) · 30k lines of lib code · 3,507 tests · 5 platforms</b><br>
+  <b>20 plugins · 49 agents · 41 skills (across all repos) · 30k lines of lib code · 3,507 tests · 5 platforms</b><br>
   <em>Plugins distributed as standalone repos under <a href="https://github.com/agent-sh">agent-sh</a> org - agentsys is the marketplace &amp; installer</em>
 </p>
 
@@ -45,7 +45,7 @@ AI models can write code. That's not the hard part anymore. The hard part is eve
 
 ## What This Is
 
-An agent orchestration system - 19 plugins, 49 agents (39 file-based + 10 role-based specialists in audit-project), and 41 skills that compose into structured pipelines for software development. Each plugin lives in its own standalone repo under the [agent-sh](https://github.com/agent-sh) org. agentsys is the marketplace and installer that ties them together.
+An agent orchestration system - 20 plugins, 49 agents (39 file-based + 10 role-based specialists in audit-project), and 41 skills that compose into structured pipelines for software development. Each plugin lives in its own standalone repo under the [agent-sh](https://github.com/agent-sh) org. agentsys is the marketplace and installer that ties them together.
 
 Each agent has a single responsibility, a specific model assignment, and defined inputs/outputs. Pipelines enforce phase gates so agents can't skip steps. State persists across sessions so work survives interruptions.
 

--- a/__tests__/cli-subcommands.test.js
+++ b/__tests__/cli-subcommands.test.js
@@ -107,7 +107,7 @@ describe('searchPlugins', () => {
     const output = logOutput.join('\n');
     expect(output).toContain('next-task');
     expect(output).toContain('deslop');
-    expect(output).toContain('19 plugin(s) found');
+    expect(output).toContain('20 plugin(s) found');
   });
 
   test('filters by name', () => {
@@ -366,10 +366,10 @@ describe('granular install recording', () => {
 });
 
 describe('loadMarketplace', () => {
-  test('loads marketplace.json with 19 plugins', () => {
+  test('loads marketplace.json with 20 plugins', () => {
     const marketplace = loadMarketplace();
     expect(marketplace.plugins).toBeDefined();
-    expect(marketplace.plugins.length).toBe(19);
+    expect(marketplace.plugins.length).toBe(20);
   });
 
   test('all plugins have name, source, version', () => {

--- a/__tests__/cli-subcommands.test.js
+++ b/__tests__/cli-subcommands.test.js
@@ -107,7 +107,11 @@ describe('searchPlugins', () => {
     const output = logOutput.join('\n');
     expect(output).toContain('next-task');
     expect(output).toContain('deslop');
-    expect(output).toContain('20 plugin(s) found');
+    // Count derived from marketplace.json so this test stays stable as
+    // the marketplace grows. Asserts the suffix and uses the same
+    // source-of-truth the production code reads.
+    const expectedCount = loadMarketplace().plugins.length;
+    expect(output).toContain(`${expectedCount} plugin(s) found`);
   });
 
   test('filters by name', () => {
@@ -366,10 +370,17 @@ describe('granular install recording', () => {
 });
 
 describe('loadMarketplace', () => {
-  test('loads marketplace.json with 20 plugins', () => {
+  test('loads marketplace.json with at least one plugin including the canonical core set', () => {
     const marketplace = loadMarketplace();
     expect(marketplace.plugins).toBeDefined();
-    expect(marketplace.plugins.length).toBe(20);
+    expect(marketplace.plugins.length).toBeGreaterThan(0);
+    // Spot-check a few plugins that anchor the marketplace identity.
+    // These are unlikely to ever be removed - if any of them is, the
+    // change deserves an explicit, visible test update.
+    const names = marketplace.plugins.map(p => p.name);
+    for (const required of ['next-task', 'ship', 'agnix']) {
+      expect(names).toContain(required);
+    }
   });
 
   test('all plugins have name, source, version', () => {

--- a/__tests__/generate-docs.test.js
+++ b/__tests__/generate-docs.test.js
@@ -166,20 +166,28 @@ describe('generate-docs', () => {
   });
 
   describe('generateAgentCounts', () => {
+    // Mirrors the production fallback in generateAgentCounts: when local
+    // discovery is empty (post-graduation, plugins live in standalone repos)
+    // the function reports the canonical project-wide STATIC_AGENT_COUNT
+    // instead of just the locally-discoverable agents.
+    function expectedTotalAgents(agents) {
+      return agents.length > 0
+        ? agents.length + genDocs.ROLE_BASED_AGENT_COUNT
+        : genDocs.STATIC_AGENT_COUNT;
+    }
+
     test('includes total agent count', () => {
       const agents = discovery.discoverAgents(REPO_ROOT);
       const plugins = discovery.discoverPlugins(REPO_ROOT);
       const counts = genDocs.generateAgentCounts(agents, plugins);
-      const totalAgents = agents.length + genDocs.ROLE_BASED_AGENT_COUNT;
-      expect(counts).toContain(`${totalAgents} agents`);
+      expect(counts).toContain(`${expectedTotalAgents(agents)} agents`);
     });
 
     test('includes AGENT_COUNT_TOTAL comment', () => {
       const agents = discovery.discoverAgents(REPO_ROOT);
       const plugins = discovery.discoverPlugins(REPO_ROOT);
       const counts = genDocs.generateAgentCounts(agents, plugins);
-      const totalAgents = agents.length + genDocs.ROLE_BASED_AGENT_COUNT;
-      expect(counts).toContain(`<!-- AGENT_COUNT_TOTAL: ${totalAgents} -->`);
+      expect(counts).toContain(`<!-- AGENT_COUNT_TOTAL: ${expectedTotalAgents(agents)} -->`);
     });
 
     test('counts plugins with agents correctly', () => {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,11 +73,12 @@ agentsys/
     ├── KNOWLEDGE-LIBRARY.md      # Index
     └── *-REFERENCE.md            # Research documents
 
-NOTE: plugins/ has been removed. All 19 plugins are now standalone repos
+NOTE: plugins/ has been removed. All 20 plugins are now standalone repos
 under the agent-sh org. The installer fetches them from GitHub at install time.
 Plugin repos: agent-sh/{next-task,prepare-delivery,gate-and-ship,ship,deslop,
               audit-project,enhance,perf,drift-detect,sync-docs,repo-intel,
-              learn,consult,debate,agnix,web-ctl,skillers,onboard,can-i-help}
+              learn,consult,debate,agnix,web-ctl,skillers,onboard,can-i-help,
+              zig-lsp}
 ```
 
 ### Cross-Platform Library (`lib/cross-platform/`)
@@ -274,7 +275,7 @@ Research documents informing the implementation (in `agent-docs/`):
 
 **Update workflow:**
 1. Edit files in `lib/` (canonical source in this repo)
-2. Push to main — agent-core sync pipeline automatically opens PRs in all 19 plugin repos
+2. Push to main — agent-core sync pipeline automatically opens PRs in all 20 plugin repos
 3. Merge those PRs in each plugin repo
 4. Publish agentsys: `npm version patch && npm publish`
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -275,7 +275,7 @@ Research documents informing the implementation (in `agent-docs/`):
 
 **Update workflow:**
 1. Edit files in `lib/` (canonical source in this repo)
-2. Push to main — agent-core sync pipeline automatically opens PRs in all 20 plugin repos
+2. Push to main — agent-core sync pipeline automatically opens PRs in 19 plugin repos today (`zig-lsp` sync wire-up still pending; tracked in docs/ORG_ARCHITECTURE.md)
 3. Merge those PRs in each plugin repo
 4. Publish agentsys: `npm version patch && npm publish`
 

--- a/docs/ORG_ARCHITECTURE.md
+++ b/docs/ORG_ARCHITECTURE.md
@@ -103,6 +103,10 @@
 - [x] marketplace `requires` field added for peer dependency tracking
 - [x] agent-core sync pipeline extended to all 19 plugin repos
 
+**Post-extraction additions:**
+- [x] `zig-lsp` registered as 20th plugin (born standalone, not extracted; LSP plugin distributed via Claude Code marketplace mechanism)
+- [ ] agent-core sync pipeline extended to `zig-lsp` (config-only plugin; sync surface is smaller — likely just CLAUDE.md/AGENTS.md mirror enforcement)
+
 ---
 
 ### 2. Plugin Distribution Registry

--- a/docs/reference/AGENTS.md
+++ b/docs/reference/AGENTS.md
@@ -3,7 +3,7 @@
 Complete reference for all agents in AgentSys.
 
 <!-- GEN:START:agents-counts -->
-**TL;DR:** 10 agents across 0 plugins (1 have agents). opus for reasoning, sonnet for patterns, haiku for execution. Each agent does one thing well. <!-- AGENT_COUNT_TOTAL: 10 -->
+**TL;DR:** 49 agents across 20 plugins (18 have agents). opus for reasoning, sonnet for patterns, haiku for execution. Each agent does one thing well. <!-- AGENT_COUNT_TOTAL: 49 -->
 <!-- GEN:END:agents-counts -->
 
 ---
@@ -24,7 +24,7 @@ Complete reference for all agents in AgentSys.
 
 ## Overview
 
-AgentSys uses 47 specialized agents across 20 plugins (17 have agents; ship and gate-and-ship are commands-only; zig-lsp is a config-only LSP plugin with no commands or agents). Each agent is optimized for a specific task and assigned a model based on complexity:
+AgentSys uses 49 specialized agents across 20 plugins (18 have agents; gate-and-ship is commands-only; zig-lsp is a config-only LSP plugin with no commands or agents). Each agent is optimized for a specific task and assigned a model based on complexity:
 
 | Model | Use Case | Cost |
 |-------|----------|------|
@@ -33,7 +33,7 @@ AgentSys uses 47 specialized agents across 20 plugins (17 have agents; ship and 
 | haiku | Mechanical execution, no judgment | Low |
 
 **Agent types:**
-- **File-based agents** (37) - Defined in `plugins/*/agents/*.md` with frontmatter <!-- AGENT_COUNT_FILE_BASED: 37 -->
+- **File-based agents** (39) - Defined in `plugins/*/agents/*.md` with frontmatter <!-- AGENT_COUNT_FILE_BASED: 39 -->
 - **Role-based agents** (10) - Defined inline via Task tool with specialized prompts <!-- AGENT_COUNT_ROLE_BASED: 10 -->
 
 ---

--- a/docs/reference/AGENTS.md
+++ b/docs/reference/AGENTS.md
@@ -24,7 +24,7 @@ Complete reference for all agents in AgentSys.
 
 ## Overview
 
-AgentSys uses 47 specialized agents across 19 plugins (17 have agents - ship and gate-and-ship use commands only). Each agent is optimized for a specific task and assigned a model based on complexity:
+AgentSys uses 47 specialized agents across 20 plugins (17 have agents; ship and gate-and-ship are commands-only; zig-lsp is a config-only LSP plugin with no commands or agents). Each agent is optimized for a specific task and assigned a model based on complexity:
 
 | Model | Use Case | Cost |
 |-------|----------|------|

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -418,7 +418,8 @@ const STATIC_PLUGIN_AGENT_COUNTS = {
   'web-ctl': 1,
   'skillers': 2,
   'onboard': 1,
-  'can-i-help': 1
+  'can-i-help': 1,
+  'zig-lsp': 0
 };
 const STATIC_PLUGIN_COUNT = Object.keys(STATIC_PLUGIN_AGENT_COUNTS).length;
 const STATIC_FILE_BASED_AGENT_COUNT = Object.values(STATIC_PLUGIN_AGENT_COUNTS).reduce((sum, count) => sum + count, 0);

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -373,20 +373,31 @@ function generateAgentNavTable(agents, plugins) {
 
 /**
  * Generate the agents count summary line for docs/reference/AGENTS.md.
+ *
+ * Uses static fallbacks when local discovery returns nothing — the agentsys
+ * monorepo no longer contains plugins/, so discovery is empty in CI. Static
+ * counts are derived from STATIC_PLUGIN_AGENT_COUNTS so they stay in sync as
+ * plugins are added.
  */
 function generateAgentCounts(agents, plugins) {
-  const fileBasedAgents = agents.length;
-  const totalAgents = fileBasedAgents + ROLE_BASED_AGENT_COUNT;
+  const totalAgents = agents.length > 0
+    ? agents.length + ROLE_BASED_AGENT_COUNT
+    : STATIC_AGENT_COUNT;
+  const totalPlugins = plugins.length > 0 ? plugins.length : STATIC_PLUGIN_COUNT;
 
-  // Count plugins with agents (file-based or role-based)
-  const pluginsWithAgents = new Set();
-  for (const agent of agents) {
-    pluginsWithAgents.add(agent.plugin);
+  let pluginsWithAgentsCount;
+  if (agents.length > 0) {
+    const pluginsWithAgents = new Set(agents.map(a => a.plugin));
+    pluginsWithAgents.add('audit-project'); // role-based
+    pluginsWithAgentsCount = pluginsWithAgents.size;
+  } else {
+    // Static fallback: file-based plugins (count > 0 in static map) plus
+    // audit-project (role-based, count is 0 in the map but still has agents).
+    const fileBasedPluginsWithAgents = Object.values(STATIC_PLUGIN_AGENT_COUNTS).filter(c => c > 0).length;
+    pluginsWithAgentsCount = fileBasedPluginsWithAgents + 1;
   }
-  pluginsWithAgents.add('audit-project'); // role-based
-  const pluginCount = pluginsWithAgents.size;
 
-  return `**TL;DR:** ${totalAgents} agents across ${plugins.length} plugins (${pluginCount} have agents). opus for reasoning, sonnet for patterns, haiku for execution. Each agent does one thing well. <!-- AGENT_COUNT_TOTAL: ${totalAgents} -->`;
+  return `**TL;DR:** ${totalAgents} agents across ${totalPlugins} plugins (${pluginsWithAgentsCount} have agents). opus for reasoning, sonnet for patterns, haiku for execution. Each agent does one thing well. <!-- AGENT_COUNT_TOTAL: ${totalAgents} -->`;
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/plugins.txt
+++ b/scripts/plugins.txt
@@ -17,3 +17,4 @@ ship
 skillers
 sync-docs
 web-ctl
+zig-lsp

--- a/site/content.json
+++ b/site/content.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "agentsys",
-    "description": "A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 41 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.",
+    "description": "A modular runtime and orchestration system for AI agents. 20 plugins, 49 agents, 41 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.",
     "url": "https://agent-sh.github.io/agentsys",
     "repo": "https://github.com/agent-sh/agentsys",
     "npm": "https://www.npmjs.com/package/agentsys",
@@ -23,7 +23,7 @@
   },
   "stats": [
     {
-      "value": "19",
+      "value": "20",
       "label": "Plugins",
       "suffix": ""
     },

--- a/site/index.html
+++ b/site/index.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>AgentSys - Agent Runtime &amp; Orchestration System</title>
-  <meta name="description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 41 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
+  <meta name="description" content="A modular runtime and orchestration system for AI agents. 20 plugins, 49 agents, 41 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
   <meta name="theme-color" content="#09090b">
 
   <!-- Open Graph -->
   <meta property="og:title" content="AgentSys">
-  <meta property="og:description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 41 skills.">
+  <meta property="og:description" content="A modular runtime and orchestration system for AI agents. 20 plugins, 49 agents, 41 skills.">
   <meta property="og:image" content="https://agent-sh.github.io/agentsys/assets/logo.png">
   <meta property="og:url" content="https://agent-sh.github.io/agentsys/">
   <meta property="og:type" content="website">
@@ -17,7 +17,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="AgentSys">
-  <meta name="twitter:description" content="AI workflow automation. 19 plugins, 49 agents, 41 skills.">
+  <meta name="twitter:description" content="AI workflow automation. 20 plugins, 49 agents, 41 skills.">
   <meta name="twitter:image" content="https://agent-sh.github.io/agentsys/assets/logo.png">
 
   <!-- Content Security Policy -->
@@ -107,7 +107,7 @@
       <div class="hero__inner">
         <div class="hero__content">
           <div class="hero__badge anim-fade-in" data-delay="100">
-            19 plugins &middot; 49 agents &middot; 41 skills
+            20 plugins &middot; 49 agents &middot; 41 skills
           </div>
           <h1 class="hero__title anim-fade-up" id="hero-title" data-delay="200">
             A modular <span class="text-gradient">runtime and orchestration system</span><br>
@@ -156,7 +156,7 @@
     <section class="stats" id="stats" aria-label="Project statistics">
       <div class="stats__inner">
         <div class="stats__item">
-          <span class="stats__number" aria-live="polite" data-target="19">0</span>
+          <span class="stats__number" aria-live="polite" data-target="20">0</span>
           <span class="stats__label">Plugins</span>
         </div>
         <div class="stats__item">
@@ -749,7 +749,7 @@
         </div>
 
         <!-- Skills grid -->
-        <h3 class="agents-skills__skills-title anim-fade-up" data-delay="300">41 Skills across 19 Plugins</h3>
+        <h3 class="agents-skills__skills-title anim-fade-up" data-delay="300">41 Skills across 20 Plugins</h3>
         <div class="skills-grid anim-fade-up" data-delay="350">
           <div class="skill-group">
             <span class="skill-group__label">prepare-delivery</span>

--- a/site/index.html
+++ b/site/index.html
@@ -749,7 +749,7 @@
         </div>
 
         <!-- Skills grid -->
-        <h3 class="agents-skills__skills-title anim-fade-up" data-delay="300">41 Skills across 20 Plugins</h3>
+        <h3 class="agents-skills__skills-title anim-fade-up" data-delay="300">41 Skills across 19 Plugins</h3>
         <div class="skills-grid anim-fade-up" data-delay="350">
           <div class="skill-group">
             <span class="skill-group__label">prepare-delivery</span>

--- a/site/ux-spec.md
+++ b/site/ux-spec.md
@@ -94,7 +94,7 @@ Scroll order with rationale for each section. All sections are full-width, alter
 - **Single column on mobile:** Text above, terminal below. Stack with 48px gap.
 
 ### Left Column Content
-1. **Badge** (top, above title): Small pill showing version or "19 plugins . 49 agents . 41 skills"
+1. **Badge** (top, above title): Small pill showing version or "20 plugins . 49 agents . 41 skills"
    - Background: `rgba(99, 102, 241, 0.12)`, border: `1px solid rgba(99, 102, 241, 0.25)`, border-radius: 9999px
    - Font: 13px, font-weight 500, primary accent color
    - Padding: 4px 14px
@@ -104,7 +104,7 @@ Scroll order with rationale for each section. All sections are full-width, alter
    - Color: white
    - "entire dev workflow" portion highlighted with a subtle gradient text (primary-to-secondary accent via `background-clip: text`)
 
-3. **Subtitle:** "19 plugins, 49 agents, 41 skills. From task selection to merged PR. Works with Claude Code, OpenCode, Codex CLI, Cursor, and Kiro."
+3. **Subtitle:** "20 plugins, 49 agents, 41 skills. From task selection to merged PR. Works with Claude Code, OpenCode, Codex CLI, Cursor, and Kiro."
    - Font: 18px on desktop, 16px on mobile, font-weight 400, line-height 1.6
    - Color: `rgba(255, 255, 255, 0.6)`
    - Max-width: 520px
@@ -226,7 +226,7 @@ Done. Task to merged PR in 12 minutes.
 ### Stats (left to right)
 | Stat | Value | Label |
 |------|-------|-------|
-| 1 | 19 | Plugins |
+| 1 | 20 | Plugins |
 | 2 | 49 | Agents |
 | 3 | 40 | Skills |
 | 4 | 3,507 | Tests Passing |
@@ -650,13 +650,13 @@ This disables:
 ### Head Content
 ```html
 <title>AgentSys - Agent Runtime &amp; Orchestration System</title>
-<meta name="description" content="A modular runtime and orchestration system for AI agents. 19 plugins, 49 agents, 41 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
+<meta name="description" content="A modular runtime and orchestration system for AI agents. 20 plugins, 49 agents, 41 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="theme-color" content="#0a0a0f">
 
 <!-- Open Graph -->
 <meta property="og:title" content="AgentSys">
-<meta property="og:description" content="AI workflow automation. 19 plugins, 49 agents, 41 skills. Task to merged PR.">
+<meta property="og:description" content="AI workflow automation. 20 plugins, 49 agents, 41 skills. Task to merged PR.">
 <meta property="og:image" content="https://agent-sh.github.io/agentsys/assets/og-image.png">
 <meta property="og:url" content="https://agent-sh.github.io/agentsys/">
 <meta property="og:type" content="website">
@@ -664,7 +664,7 @@ This disables:
 <!-- Twitter Card -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AgentSys">
-<meta name="twitter:description" content="AI workflow automation. 19 plugins, 49 agents, 41 skills.">
+<meta name="twitter:description" content="AI workflow automation. 20 plugins, 49 agents, 41 skills.">
 <meta name="twitter:image" content="https://agent-sh.github.io/agentsys/assets/og-image.png">
 ```
 

--- a/site/ux-spec.md
+++ b/site/ux-spec.md
@@ -228,7 +228,7 @@ Done. Task to merged PR in 12 minutes.
 |------|-------|-------|
 | 1 | 20 | Plugins |
 | 2 | 49 | Agents |
-| 3 | 40 | Skills |
+| 3 | 41 | Skills |
 | 4 | 3,507 | Tests Passing |
 
 ### Styling


### PR DESCRIPTION
## Summary

Adds [agent-sh/zig-lsp](https://github.com/agent-sh/zig-lsp) as the **20th plugin** in the agentsys marketplace. Users will be able to install it via `/plugin install zig-lsp@agentsys` after merge.

`zig-lsp` is a **config-only LSP plugin** - no commands, no agents, no skills. It's a thin `.lsp.json` manifest that maps `.zig` and `.zon` files to user-installed `zls` (Zig Language Server). Claude Code's built-in `LSP` tool dispatches to it automatically; the auto-diagnostics post-edit hook surfaces type errors without a manual build step.

This is the first non-workflow plugin in the agentsys marketplace - it sits in category `development` alongside `agnix`, `audit-project`, etc., but its surface differs from the rest (LSP integration vs. slash commands).

## Changes

| File | Change |
| --- | --- |
| `.claude-plugin/marketplace.json` | +zig-lsp entry; description `19 specialized plugins` -> `20 ... and Zig language support` |
| `scripts/plugins.txt` | +`zig-lsp` (alphabetical) |
| `scripts/generate-docs.js` | +`'zig-lsp': 0` in `STATIC_PLUGIN_AGENT_COUNTS`; `generateAgentCounts` now uses static fallbacks when local discovery is empty (post-graduation reality), so the auto-gen `agents-counts` block reports the canonical project-wide count instead of `10 agents across 0 plugins` |
| `site/content.json` | meta description + Plugins stat `19` -> `20` |
| `site/index.html` | 5 hand-written count mentions: 3 meta tags, hero badge, stats `data-target`. The `41 Skills across N Plugins` heading stays at 19 because zig-lsp contributes 0 skills |
| `__tests__/cli-subcommands.test.js` | Refactored from hardcoded plugin count to dynamic count derived from `loadMarketplace().plugins.length` + core-plugin presence assertions |
| `__tests__/generate-docs.test.js` | Tracks the same fallback logic as production (`generateAgentCounts`) |
| Prose docs (`AGENTS.md`, `README.md`, `docs/ARCHITECTURE.md`, `docs/reference/AGENTS.md`, `docs/ORG_ARCHITECTURE.md`, `site/ux-spec.md`) | Plugin-count bumps; agent-count corrections (`47 / 17 have agents` -> `49 / 18`, since `ship` does have one agent at `release-agent.md`); milestone records preserved at 19 in ORG_ARCHITECTURE.md with new "Post-extraction additions" block tracking zig-lsp |
| `CHANGELOG.md` | [Unreleased] entry |

## Deliberate non-changes

| Area | Reason |
| --- | --- |
| `site/index.html` tab UI | Tabs are keyed on slash commands (`20 Commands. One Toolkit.`), not plugins. zig-lsp ships zero commands - adding a tab would misrepresent its surface. The plugin count is reflected in stats counter, hero badge, meta tags |
| `docs/ORG_ARCHITECTURE.md` milestone records | "All 19 plugins extracted" / "sync pipeline extended to 19 repos" record the historical extraction effort. zig-lsp was born standalone, not extracted. Added a `Post-extraction additions` block instead with `[x]` for the registration and `[ ]` for the open agent-core sync wire-up |

## Test plan

- [x] CI tests pass (the `generate-docs --check` doc-freshness test that the first revision broke is now green; `cli-subcommands` and `generate-docs` test suites both 100% green locally)
- [ ] After merge: `/plugin marketplace update agentsys` then `/plugin install zig-lsp@agentsys` succeeds
- [ ] After merge: site shows `20 plugins` in badge / stats / meta tags
- [x] No CI changes needed in zig-lsp repo - it has its own `agnix` workflow already green

Remaining CI failures on this PR are pre-existing on `main` (`workflow-state.tasks.json operations` x14, `cross-platform.truncate` emoji surrogate / negative maxLength x2, `repo-intel-queries` missing module x1) - verified head-to-head against [main run 24917780915](https://github.com/agent-sh/agentsys/actions/runs/24917780915). PR introduces zero new failures.

## Source

- Plugin repo: https://github.com/agent-sh/zig-lsp
- Plugin marketplace.json: `agent-sh` (the zig-lsp repo IS its own standalone marketplace; agentsys aggregates via `source.url`)

## Review feedback addressed

All 8 unresolved threads from Copilot + Gemini have been addressed in commit 8a7ac11 with per-thread replies. Summary:

- Tests refactored to dynamic plugin count (Copilot x2)
- `generate-docs.js` correctly updated with consistency note (was missing from earlier description; Gemini HIGH + Copilot)
- `41 Skills across 20 Plugins` reverted to 19 (Gemini MEDIUM)
- `agent-core sync` phrasing softened to reflect pending zig-lsp sync (Copilot)
- `ux-spec.md` skills-row pre-existing typo `40` -> `41` (Copilot)
- `reference/AGENTS.md` auto-gen block now produces canonical project-wide counts via static fallback (Copilot)