### PR TITLE
fix(security): pin marketplace plugins, SHA-pin workflows, env-var shell args

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -173,7 +173,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/agent-sh/agnix.git",
-        "commit": "24efafb6d670cb6b6c0394afe69c1cdce585534a"
+        "commit": "5af38eed0263cee3d5d48be8dae87746172b914d"
       },
       "description": "Lint agent configuration files (SKILL.md, CLAUDE.md, hooks, MCP) against 414 rules across 10+ AI tools",
       "version": "1.1.0",
@@ -209,7 +209,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/agent-sh/web-ctl.git",
-        "commit": "63b20d864d51a9c3f6afe279fd6598849eaa5d60"
+        "commit": "5e420b81ffb7a16f4336dca865660d62d10aebc1"
       },
       "description": "Browser automation and web testing toolkit for AI agents - headless browser control, persistent sessions, auth handoff, and prompt injection defense",
       "version": "1.0.0",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,9 @@
       "name": "next-task",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/next-task.git"
+        "url": "https://github.com/agent-sh/next-task.git",
+        "ref": "v1.1.1",
+        "commit": "9aa32b856d81ebeeb6c6ea0ab421c80d6986a7b1"
       },
       "description": "Master workflow orchestrator: autonomous workflow with model optimization (opus/sonnet/haiku), two-file state management, workflow enforcement gates, 8 specialist agents",
       "version": "1.1.1",
@@ -37,7 +39,8 @@
       "name": "prepare-delivery",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/prepare-delivery.git"
+        "url": "https://github.com/agent-sh/prepare-delivery.git",
+        "commit": "2e8f400115d8df68e6e8e02466a97117c7f86fab"
       },
       "description": "Pre-ship quality gates: deslop, simplify, agnix, enhance, review loop, delivery validation, docs sync",
       "version": "0.1.0",
@@ -48,7 +51,8 @@
       "name": "gate-and-ship",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/gate-and-ship.git"
+        "url": "https://github.com/agent-sh/gate-and-ship.git",
+        "commit": "bfff7063fde89a05ce480e37019bb6e00ba55984"
       },
       "description": "Quality gates then ship - chains /prepare-delivery then /ship in one command",
       "version": "0.1.0",
@@ -59,7 +63,8 @@
       "name": "ship",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/ship.git"
+        "url": "https://github.com/agent-sh/ship.git",
+        "commit": "adec0f552eb8bd71c62f3a5feee502d4951c909a"
       },
       "description": "Complete PR workflow: commit to production, skips review when called from next-task, removes task from registry on cleanup, automatic rollback",
       "version": "1.0.0",
@@ -70,7 +75,8 @@
       "name": "deslop",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/deslop.git"
+        "url": "https://github.com/agent-sh/deslop.git",
+        "commit": "35e726b073356bfc44a112aeecc085af4624f318"
       },
       "description": "3-phase AI slop detection: regex patterns (HIGH), multi-pass analyzers (MEDIUM), CLI tools (LOW)",
       "version": "1.0.0",
@@ -81,7 +87,8 @@
       "name": "audit-project",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/audit-project.git"
+        "url": "https://github.com/agent-sh/audit-project.git",
+        "commit": "11a00874f7a10d28fe5c44e69a19d4364d364a78"
       },
       "description": "Multi-agent iterative code review until zero issues remain",
       "version": "1.0.0",
@@ -92,7 +99,8 @@
       "name": "drift-detect",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/drift-detect.git"
+        "url": "https://github.com/agent-sh/drift-detect.git",
+        "commit": "baf9bed640a14516d5dcfd084b5d405f4d2c4d73"
       },
       "description": "Deep repository analysis to realign project plans with code reality - detects drift, gaps, and creates prioritized reconstruction plans",
       "version": "1.0.0",
@@ -103,7 +111,8 @@
       "name": "enhance",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/enhance.git"
+        "url": "https://github.com/agent-sh/enhance.git",
+        "commit": "713da42f940d3a899a4930b873162d1615f817b7"
       },
       "description": "Master enhancement orchestrator: parallel analyzer execution for plugins, agents, docs, CLAUDE.md, and prompts with unified reporting",
       "version": "1.0.0",
@@ -114,7 +123,8 @@
       "name": "sync-docs",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/sync-docs.git"
+        "url": "https://github.com/agent-sh/sync-docs.git",
+        "commit": "6f6cf735824d38a0884cdacceac0f0eb285b7cb1"
       },
       "description": "Standalone documentation sync: find outdated refs, update CHANGELOG, flag stale examples based on code changes",
       "version": "1.0.0",
@@ -125,7 +135,9 @@
       "name": "repo-intel",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/repo-intel.git"
+        "url": "https://github.com/agent-sh/repo-intel.git",
+        "ref": "v0.2.0",
+        "commit": "100dbff1969097af5e6a2ede7a2a79400aa0e60f"
       },
       "description": "Unified static analysis via agent-analyzer - git history, AST symbols, project metadata, and doc-code sync",
       "version": "0.2.0",
@@ -136,7 +148,8 @@
       "name": "perf",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/perf.git"
+        "url": "https://github.com/agent-sh/perf.git",
+        "commit": "5444eb6fe156d78e2efccb2278c5ec4d9dec15f2"
       },
       "description": "Rigorous performance investigation workflow with baselines, profiling, hypotheses, and evidence-backed decisions",
       "version": "1.0.0",
@@ -147,7 +160,8 @@
       "name": "learn",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/learn.git"
+        "url": "https://github.com/agent-sh/learn.git",
+        "commit": "f5c357910f82e148200518fba12108c6a1af01a6"
       },
       "description": "Research topics online and create comprehensive learning guides with RAG-optimized indexes",
       "version": "1.0.0",
@@ -158,7 +172,8 @@
       "name": "agnix",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/agnix.git"
+        "url": "https://github.com/agent-sh/agnix.git",
+        "commit": "24efafb6d670cb6b6c0394afe69c1cdce585534a"
       },
       "description": "Lint agent configuration files (SKILL.md, CLAUDE.md, hooks, MCP) against 414 rules across 10+ AI tools",
       "version": "1.1.0",
@@ -169,7 +184,8 @@
       "name": "consult",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/consult.git"
+        "url": "https://github.com/agent-sh/consult.git",
+        "commit": "84a1cf541c3feebc4d79010677d6fdb9460c32fb"
       },
       "description": "Cross-tool AI consultation: get second opinions from Gemini CLI, Codex CLI, Claude Code, OpenCode, or Copilot CLI with model and thinking effort control",
       "version": "1.0.0",
@@ -180,7 +196,8 @@
       "name": "debate",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/debate.git"
+        "url": "https://github.com/agent-sh/debate.git",
+        "commit": "96be5d4d2224cc4b90ebec58a210ec6928832917"
       },
       "description": "Structured multi-round debate between AI tools with proposer/challenger roles and verdict",
       "version": "1.0.0",
@@ -191,7 +208,8 @@
       "name": "web-ctl",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/web-ctl.git"
+        "url": "https://github.com/agent-sh/web-ctl.git",
+        "commit": "63b20d864d51a9c3f6afe279fd6598849eaa5d60"
       },
       "description": "Browser automation and web testing toolkit for AI agents - headless browser control, persistent sessions, auth handoff, and prompt injection defense",
       "version": "1.0.0",
@@ -202,7 +220,8 @@
       "name": "skillers",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/skillers.git"
+        "url": "https://github.com/agent-sh/skillers.git",
+        "commit": "88efb0346b2582a224f3f85db72450b9f3ba7507"
       },
       "description": "Learn from workflow patterns across sessions and suggest skills, hooks, and agents to automate repetitive work",
       "version": "1.0.0",
@@ -213,7 +232,9 @@
       "name": "onboard",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/onboard.git"
+        "url": "https://github.com/agent-sh/onboard.git",
+        "ref": "v0.1.0",
+        "commit": "7444d6475055897498a348639dd0bcb12ba7906b"
       },
       "description": "Codebase onboarding - automated data collection and interactive project orientation",
       "version": "0.1.0",
@@ -224,7 +245,9 @@
       "name": "can-i-help",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/can-i-help.git"
+        "url": "https://github.com/agent-sh/can-i-help.git",
+        "ref": "v0.1.0",
+        "commit": "5610a54ce9200577879a0ad8a9dc174133f56abf"
       },
       "description": "Find where to contribute to any project - matches developer skills to test gaps, stale docs, bugspots, and open issues",
       "version": "0.1.0",
@@ -235,7 +258,8 @@
       "name": "zig-lsp",
       "source": {
         "source": "url",
-        "url": "https://github.com/agent-sh/zig-lsp.git"
+        "url": "https://github.com/agent-sh/zig-lsp.git",
+        "commit": "ecf32677d7bb3cc8e28112bb3c70dd7809a3aea7"
       },
       "description": "Zig language server for Claude Code via ZLS - automatic diagnostics after every edit, jump-to-definition, find-references, and hover. Requires zls in PATH",
       "version": "0.1.0",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,6 @@ jobs:
         run: node scripts/gen-adapters.js --check
 
   agnix:
-    uses: agent-sh/.github/.github/workflows/ci-agnix.yml@main
+    # SHA pin to agent-sh/.github main. Update by running:
+    #   gh api repos/agent-sh/.github/commits/main --jq .sha
+    uses: agent-sh/.github/.github/workflows/ci-agnix.yml@08a935dedfecab8524861c2db72526007445ba52 # main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,14 +38,16 @@ jobs:
 
       - name: Determine version
         id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             # Tag push - extract version from tag
             TAG="${GITHUB_REF#refs/tags/}"
             VERSION="${TAG#v}"
-          elif [ -n "${{ inputs.version }}" ]; then
+          elif [ -n "$INPUT_VERSION" ]; then
             # Manual dispatch with version input
-            VERSION="${{ inputs.version }}"
+            VERSION="$INPUT_VERSION"
             TAG="v${VERSION}"
           else
             # Manual dispatch without version - use package.json
@@ -70,8 +72,9 @@ jobs:
           echo "[PKG] npm tag: ${NPM_TAG}"
 
       - name: Validate version format
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
             echo "[ERROR] Invalid version format: $VERSION"
             echo "Expected: X.Y.Z or X.Y.Z-prerelease"
@@ -97,9 +100,9 @@ jobs:
           echo "[OK] Release source ref is valid"
 
       - name: Verify version consistency
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
           echo "Checking version consistency across all files..."
 
           # Check package.json
@@ -192,8 +195,9 @@ jobs:
 
       - name: Create tag if needed
         if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          TAG: ${{ needs.validate.outputs.tag }}
         run: |
-          TAG="${{ needs.validate.outputs.tag }}"
           if ! git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "Creating tag: $TAG"
             git tag "$TAG"
@@ -204,9 +208,9 @@ jobs:
 
       - name: Extract changelog for version
         id: changelog
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
         run: |
-          VERSION="${{ needs.validate.outputs.version }}"
-
           # Extract changelog section for this version
           CHANGELOG=$(awk "/^## \\[${VERSION}\\]/{flag=1; next} /^## \\[/{flag=0} flag" CHANGELOG.md)
 

--- a/__tests__/pin-marketplace.test.js
+++ b/__tests__/pin-marketplace.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const {
+  parseOrgRepo,
+  resolveTagSha,
+  pinPlugin,
+  setGhRunner,
+} = require('../scripts/pin-marketplace.js');
+
+afterEach(() => {
+  setGhRunner(null); // reset to default
+});
+
+describe('parseOrgRepo', () => {
+  test.each([
+    ['https://github.com/agent-sh/foo.git', 'agent-sh', 'foo'],
+    ['https://github.com/agent-sh/foo', 'agent-sh', 'foo'],
+    ['https://github.com/agent-sh/foo/', 'agent-sh', 'foo'],
+    ['https://github.com/agent-sh/foo.git/', 'agent-sh', 'foo'],
+    ['git@github.com:agent-sh/foo.git', 'agent-sh', 'foo'],
+    ['https://github.com/agent-sh/next-task.git', 'agent-sh', 'next-task'],
+  ])('parses %s', (url, owner, repo) => {
+    expect(parseOrgRepo(url)).toEqual({ owner, repo });
+  });
+
+  test('throws on non-github urls', () => {
+    expect(() => parseOrgRepo('https://example.com/foo/bar')).toThrow(
+      /Cannot parse/,
+    );
+  });
+});
+
+describe('resolveTagSha', () => {
+  test('returns sha for lightweight tag', () => {
+    setGhRunner((args) => {
+      expect(args).toEqual([
+        'api',
+        'repos/owner/repo/git/ref/tags/v1.0.0',
+      ]);
+      return JSON.stringify({
+        ref: 'refs/tags/v1.0.0',
+        object: { type: 'commit', sha: 'deadbeef' },
+      });
+    });
+    expect(resolveTagSha('owner', 'repo', 'v1.0.0')).toBe('deadbeef');
+  });
+
+  test('derefs annotated tag to commit sha', () => {
+    const calls = [];
+    setGhRunner((args) => {
+      calls.push(args);
+      if (args[1] === 'repos/owner/repo/git/ref/tags/v2.0.0') {
+        return JSON.stringify({
+          object: { type: 'tag', sha: 'tagobj' },
+        });
+      }
+      if (args[1] === 'repos/owner/repo/git/tags/tagobj') {
+        return JSON.stringify({ object: { sha: 'realcommit' } });
+      }
+      throw new Error(`unexpected ${args.join(' ')}`);
+    });
+    expect(resolveTagSha('owner', 'repo', 'v2.0.0')).toBe('realcommit');
+    expect(calls).toHaveLength(2);
+  });
+
+  test('returns null on 404', () => {
+    setGhRunner(() => {
+      const err = new Error('gh api failed: Not Found');
+      err.stderr = 'HTTP 404: Not Found';
+      throw err;
+    });
+    expect(resolveTagSha('owner', 'repo', 'vnope')).toBeNull();
+  });
+
+  test('rejects ambiguous array response', () => {
+    setGhRunner(() =>
+      JSON.stringify([
+        { ref: 'refs/tags/v1.0.0', object: { sha: 'a' } },
+        { ref: 'refs/tags/v1.0.0-rc1', object: { sha: 'b' } },
+      ]),
+    );
+    expect(() => resolveTagSha('owner', 'repo', 'v1.0.0')).toThrow(
+      /Ambiguous tag lookup/,
+    );
+  });
+});
+
+describe('pinPlugin fallback behavior', () => {
+  test('pins tag+commit when tag resolves', () => {
+    setGhRunner(() =>
+      JSON.stringify({
+        object: { type: 'commit', sha: 'abc123' },
+      }),
+    );
+    const plugin = {
+      name: 'x',
+      version: '1.2.3',
+      source: { source: 'url', url: 'https://github.com/agent-sh/x.git' },
+    };
+    const result = pinPlugin(plugin);
+    expect(result.status).toBe('pinned');
+    expect(plugin.source.ref).toBe('v1.2.3');
+    expect(plugin.source.commit).toBe('abc123');
+  });
+
+  test('fallback clears stale ref from a previous pin', () => {
+    // Simulate: previous run pinned `v0.9.0` successfully; the new run has
+    // no matching tag (returns 404) and must clear the stale ref before
+    // setting the commit.
+    let call = 0;
+    setGhRunner((args) => {
+      call += 1;
+      if (call === 1) {
+        const err = new Error('not found');
+        err.stderr = '404 Not Found';
+        throw err;
+      }
+      // defaultBranchHeadSha
+      expect(args[1]).toBe('repos/agent-sh/x/commits/HEAD');
+      return 'newheadsha';
+    });
+    const plugin = {
+      name: 'x',
+      version: '1.0.0',
+      source: {
+        source: 'url',
+        url: 'https://github.com/agent-sh/x.git',
+        ref: 'v0.9.0',      // stale
+        commit: 'oldsha',   // stale
+      },
+    };
+    const result = pinPlugin(plugin);
+    expect(result.status).toBe('fallback');
+    expect(plugin.source.ref).toBeUndefined();
+    expect(plugin.source.commit).toBe('newheadsha');
+  });
+
+  test('skips non-url plugins', () => {
+    const plugin = {
+      name: 'local',
+      version: '1.0.0',
+      source: { source: 'path', path: './plugins/local' },
+    };
+    // No gh runner invocation expected.
+    setGhRunner(() => {
+      throw new Error('should not be called');
+    });
+    expect(pinPlugin(plugin).status).toBe('skipped');
+  });
+});

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -342,6 +342,15 @@ function resolvePluginDeps(names, marketplace) {
  * @param {string} version - Expected version string
  * @returns {Promise<string>} Path to extracted plugin directory
  */
+// TODO(agentsys-security): this local dev installer currently honors only
+// `source.url` + `plugin.version` and ignores `source.ref` / `source.commit`
+// from marketplace.json. Claude Code's plugin installer (the primary install
+// path for end users) DOES honor `ref` and `commit` per the marketplace
+// schema, so the pins added by scripts/pin-marketplace.js are authoritative
+// for real users. This dev CLI should be updated to prefer `source.commit`
+// (then `source.ref`, then `plugin.version`) when resolving the fetch ref,
+// so local dev gets the same supply-chain guarantees as production installs.
+// Tracked as a follow-up; not fixed in PR #347 to keep that PR scoped.
 async function fetchPlugin(name, source, version) {
   const cacheDir = getPluginCacheDir();
   const pluginDir = path.join(cacheDir, name);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "lib"
       ],
       "dependencies": {
-        "agentsys": "^5.0.0",
         "js-yaml": "~4.1.1"
       },
       "bin": {
@@ -1069,25 +1068,6 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/agentsys": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/agentsys/-/agentsys-5.0.0.tgz",
-      "integrity": "sha512-sgJtt09WI1rDzXL855mAaEXRXi0iv5kXvurLuGXua6Y/G6Vm6KdqlE4Y9JLw22zJtTw4HP4Jy2OWceT0uY05WA==",
-      "license": "MIT",
-      "workspaces": [
-        "lib"
-      ],
-      "dependencies": {
-        "js-yaml": "^4.1.1"
-      },
-      "bin": {
-        "agentsys": "bin/cli.js",
-        "agentsys-dev": "bin/dev-cli.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "agentsys": "^5.0.0",
     "js-yaml": "~4.1.1"
   },
   "devDependencies": {

--- a/scripts/pin-marketplace.js
+++ b/scripts/pin-marketplace.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * Pin each marketplace sub-plugin entry to a release tag (and commit SHA for
+ * defense in depth). Falls back to pinning current HEAD commit on main when a
+ * release tag for the declared `version` does not exist on the remote.
+ *
+ * Rationale: unpinned `source: "url"` entries let `claude plugin install`
+ * track the default branch, which is a supply-chain compromise vector. Pinning
+ * to a tag (for humans) AND the tag's resolved commit SHA (for integrity)
+ * ensures the exact bytes we ship are the exact bytes users get.
+ *
+ * Usage: node scripts/pin-marketplace.js [--dry-run]
+ *
+ * Requires: `gh` CLI authenticated against the agent-sh org.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const MARKETPLACE_PATH = path.join(
+  __dirname,
+  '..',
+  '.claude-plugin',
+  'marketplace.json',
+);
+
+function gh(args) {
+  try {
+    return execFileSync('gh', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (err) {
+    const stderr = err.stderr ? err.stderr.toString() : '';
+    const e = new Error(`gh ${args.join(' ')} failed: ${stderr || err.message}`);
+    e.stderr = stderr;
+    throw e;
+  }
+}
+
+function parseOrgRepo(gitUrl) {
+  // https://github.com/agent-sh/<name>.git -> ["agent-sh", "<name>"]
+  const m = gitUrl.match(/github\.com[:/]+([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (!m) throw new Error(`Cannot parse org/repo from ${gitUrl}`);
+  return { owner: m[1], repo: m[2] };
+}
+
+function resolveTagSha(owner, repo, tag) {
+  // Returns the commit SHA the tag resolves to, or null if tag is missing.
+  // Tags may be annotated (object.type === "tag") or lightweight. Annotated
+  // tags need a second deref step to the underlying commit.
+  let ref;
+  try {
+    ref = JSON.parse(
+      gh(['api', `repos/${owner}/${repo}/git/refs/tags/${tag}`]),
+    );
+  } catch (err) {
+    if (/Not Found|404/i.test(err.stderr || err.message)) return null;
+    throw err;
+  }
+  if (!ref || !ref.object) return null;
+  if (ref.object.type === 'commit') return ref.object.sha;
+  if (ref.object.type === 'tag') {
+    const annotated = JSON.parse(
+      gh(['api', `repos/${owner}/${repo}/git/tags/${ref.object.sha}`]),
+    );
+    return annotated.object && annotated.object.sha
+      ? annotated.object.sha
+      : null;
+  }
+  return null;
+}
+
+function headSha(owner, repo) {
+  return gh([
+    'api',
+    `repos/${owner}/${repo}/commits/main`,
+    '--jq',
+    '.sha',
+  ]);
+}
+
+function main() {
+  const raw = fs.readFileSync(MARKETPLACE_PATH, 'utf8');
+  const data = JSON.parse(raw);
+
+  const pinned = [];
+  const fallbacks = [];
+
+  for (const plugin of data.plugins) {
+    const src = plugin.source;
+    if (!src || src.source !== 'url' || !src.url) continue;
+
+    const { owner, repo } = parseOrgRepo(src.url);
+    const version = plugin.version;
+    const tag = version ? `v${version}` : null;
+
+    let sha = null;
+    if (tag) {
+      sha = resolveTagSha(owner, repo, tag);
+    }
+
+    if (sha) {
+      src.ref = tag;
+      src.commit = sha;
+      pinned.push({ name: plugin.name, tag, sha });
+      console.log(`[OK] ${plugin.name} -> ${tag} (${sha.slice(0, 10)})`);
+    } else {
+      const head = headSha(owner, repo);
+      src.commit = head;
+      // No `ref` because there is no stable tag; commit SHA is the pin.
+      fallbacks.push({ name: plugin.name, wantedTag: tag, sha: head });
+      console.log(
+        `[WARN] ${plugin.name} has no tag ${tag} on ${owner}/${repo}; pinning main@${head.slice(0, 10)}`,
+      );
+    }
+  }
+
+  const out = JSON.stringify(data, null, 2) + '\n';
+
+  if (DRY_RUN) {
+    console.log('\n[DRY-RUN] Not writing marketplace.json');
+  } else {
+    fs.writeFileSync(MARKETPLACE_PATH, out);
+    console.log(`\n[OK] Wrote ${MARKETPLACE_PATH}`);
+  }
+
+  console.log(
+    `\nSummary: ${pinned.length} pinned to tags, ${fallbacks.length} fell back to main commit SHA`,
+  );
+  if (fallbacks.length > 0) {
+    console.log('\nFallback plugins (no release tag yet):');
+    for (const f of fallbacks) {
+      console.log(`  - ${f.name}: wanted ${f.wantedTag}, pinned ${f.sha}`);
+    }
+  }
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    console.error(`[ERROR] ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/pin-marketplace.js
+++ b/scripts/pin-marketplace.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Pin each marketplace sub-plugin entry to a release tag (and commit SHA for
- * defense in depth). Falls back to pinning current HEAD commit on main when a
+ * defense in depth). Falls back to pinning current default-branch HEAD when a
  * release tag for the declared `version` does not exist on the remote.
  *
  * Rationale: unpinned `source: "url"` entries let `claude plugin install`
@@ -28,7 +28,10 @@ const MARKETPLACE_PATH = path.join(
   'marketplace.json',
 );
 
-function gh(args) {
+// Seam for tests: callers may override `ghRunner` to stub API responses.
+let ghRunner = defaultGhRunner;
+
+function defaultGhRunner(args) {
   try {
     return execFileSync('gh', args, {
       encoding: 'utf8',
@@ -42,25 +45,49 @@ function gh(args) {
   }
 }
 
+function gh(args) {
+  return ghRunner(args);
+}
+
+function setGhRunner(fn) {
+  ghRunner = typeof fn === 'function' ? fn : defaultGhRunner;
+}
+
 function parseOrgRepo(gitUrl) {
-  // https://github.com/agent-sh/<name>.git -> ["agent-sh", "<name>"]
-  const m = gitUrl.match(/github\.com[:/]+([^/]+)\/([^/]+?)(?:\.git)?$/);
+  // https://github.com/agent-sh/<name>.git    -> ["agent-sh", "<name>"]
+  // https://github.com/agent-sh/<name>        -> ["agent-sh", "<name>"]
+  // https://github.com/agent-sh/<name>/       -> ["agent-sh", "<name>"]
+  // https://github.com/agent-sh/<name>/.git   -> ["agent-sh", "<name>"]
+  // git@github.com:agent-sh/<name>.git        -> ["agent-sh", "<name>"]
+  const m = gitUrl.match(
+    /github\.com[:/]+([^/]+)\/([^/]+?)\/?(?:\.git)?\/?$/,
+  );
   if (!m) throw new Error(`Cannot parse org/repo from ${gitUrl}`);
   return { owner: m[1], repo: m[2] };
 }
 
 function resolveTagSha(owner, repo, tag) {
   // Returns the commit SHA the tag resolves to, or null if tag is missing.
+  // Uses the singular `git/ref/tags/<tag>` endpoint to get an exact match;
+  // the plural `git/refs/tags/<tag>` does prefix matching and can silently
+  // return an array when multiple tags share a prefix.
   // Tags may be annotated (object.type === "tag") or lightweight. Annotated
   // tags need a second deref step to the underlying commit.
   let ref;
   try {
     ref = JSON.parse(
-      gh(['api', `repos/${owner}/${repo}/git/refs/tags/${tag}`]),
+      gh(['api', `repos/${owner}/${repo}/git/ref/tags/${tag}`]),
     );
   } catch (err) {
     if (/Not Found|404/i.test(err.stderr || err.message)) return null;
     throw err;
+  }
+  // Defense in depth: reject unexpected array responses as ambiguous so a
+  // future endpoint-behavior shift cannot silently pick the wrong tag.
+  if (Array.isArray(ref)) {
+    throw new Error(
+      `Ambiguous tag lookup for ${owner}/${repo}@${tag}: got array of ${ref.length} refs`,
+    );
   }
   if (!ref || !ref.object) return null;
   if (ref.object.type === 'commit') return ref.object.sha;
@@ -75,13 +102,47 @@ function resolveTagSha(owner, repo, tag) {
   return null;
 }
 
-function headSha(owner, repo) {
+function defaultBranchHeadSha(owner, repo) {
+  // Use HEAD (which the API resolves to the repo's default branch) rather
+  // than hardcoding `main`. Works even if the repo still ships `master` or
+  // adopts something else later.
   return gh([
     'api',
-    `repos/${owner}/${repo}/commits/main`,
+    `repos/${owner}/${repo}/commits/HEAD`,
     '--jq',
     '.sha',
   ]);
+}
+
+function pinPlugin(plugin) {
+  const src = plugin.source;
+  if (!src || src.source !== 'url' || !src.url) {
+    return { status: 'skipped', name: plugin.name };
+  }
+
+  const { owner, repo } = parseOrgRepo(src.url);
+  const version = plugin.version;
+  const tag = version ? `v${version}` : null;
+
+  let sha = null;
+  if (tag) {
+    sha = resolveTagSha(owner, repo, tag);
+  }
+
+  if (sha) {
+    src.ref = tag;
+    src.commit = sha;
+    return { status: 'pinned', name: plugin.name, tag, sha };
+  }
+
+  const head = defaultBranchHeadSha(owner, repo);
+  // Explicitly clear any stale `ref` from a previous run: if the plugin
+  // loses its tag (e.g., deleted for a security rewrite) we must not leave
+  // the old tag reference around, since downstream installers that prefer
+  // `ref` would otherwise ignore the new commit pin.
+  delete src.ref;
+  src.commit = head;
+  return { status: 'fallback', name: plugin.name, wantedTag: tag, sha: head };
 }
 
 function main() {
@@ -90,33 +151,25 @@ function main() {
 
   const pinned = [];
   const fallbacks = [];
+  const errors = [];
 
   for (const plugin of data.plugins) {
-    const src = plugin.source;
-    if (!src || src.source !== 'url' || !src.url) continue;
-
-    const { owner, repo } = parseOrgRepo(src.url);
-    const version = plugin.version;
-    const tag = version ? `v${version}` : null;
-
-    let sha = null;
-    if (tag) {
-      sha = resolveTagSha(owner, repo, tag);
-    }
-
-    if (sha) {
-      src.ref = tag;
-      src.commit = sha;
-      pinned.push({ name: plugin.name, tag, sha });
-      console.log(`[OK] ${plugin.name} -> ${tag} (${sha.slice(0, 10)})`);
-    } else {
-      const head = headSha(owner, repo);
-      src.commit = head;
-      // No `ref` because there is no stable tag; commit SHA is the pin.
-      fallbacks.push({ name: plugin.name, wantedTag: tag, sha: head });
-      console.log(
-        `[WARN] ${plugin.name} has no tag ${tag} on ${owner}/${repo}; pinning main@${head.slice(0, 10)}`,
-      );
+    try {
+      const result = pinPlugin(plugin);
+      if (result.status === 'pinned') {
+        pinned.push(result);
+        console.log(
+          `[OK] ${result.name} -> ${result.tag} (${result.sha.slice(0, 10)})`,
+        );
+      } else if (result.status === 'fallback') {
+        fallbacks.push(result);
+        console.log(
+          `[WARN] ${result.name} has no tag ${result.wantedTag}; pinning default-branch@${result.sha.slice(0, 10)}`,
+        );
+      }
+    } catch (err) {
+      errors.push({ name: plugin.name, error: err.message });
+      console.error(`[ERROR] ${plugin.name}: ${err.message}`);
     }
   }
 
@@ -124,13 +177,17 @@ function main() {
 
   if (DRY_RUN) {
     console.log('\n[DRY-RUN] Not writing marketplace.json');
-  } else {
+  } else if (errors.length === 0) {
     fs.writeFileSync(MARKETPLACE_PATH, out);
     console.log(`\n[OK] Wrote ${MARKETPLACE_PATH}`);
+  } else {
+    console.log(
+      '\n[WARN] Not writing marketplace.json because some plugins failed; re-run after resolving errors.',
+    );
   }
 
   console.log(
-    `\nSummary: ${pinned.length} pinned to tags, ${fallbacks.length} fell back to main commit SHA`,
+    `\nSummary: ${pinned.length} pinned to tags, ${fallbacks.length} fell back to default-branch SHA, ${errors.length} errors`,
   );
   if (fallbacks.length > 0) {
     console.log('\nFallback plugins (no release tag yet):');
@@ -138,13 +195,30 @@ function main() {
       console.log(`  - ${f.name}: wanted ${f.wantedTag}, pinned ${f.sha}`);
     }
   }
+  if (errors.length > 0) {
+    console.log('\nFailed plugins:');
+    for (const e of errors) {
+      console.log(`  - ${e.name}: ${e.error}`);
+    }
+    return 1;
+  }
+  return 0;
 }
 
 if (require.main === module) {
   try {
-    main();
+    const code = main();
+    process.exit(code);
   } catch (err) {
     console.error(`[ERROR] ${err.message}`);
     process.exit(1);
   }
 }
+
+module.exports = {
+  parseOrgRepo,
+  resolveTagSha,
+  defaultBranchHeadSha,
+  pinPlugin,
+  setGhRunner,
+};


### PR DESCRIPTION
## Summary

Internal audit (2026-04-26). 4 commits:

| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| 1 | HIGH | 20 marketplace sub-plugins used unpinned \`main\` at install time — any sub-plugin compromise ships code to every user | Pin to release tag + commit SHA via new \`scripts/pin-marketplace.js\` |
| 2 | MED | \`agent-sh/.github@main\` reusable workflow not SHA-pinned | SHA pinned |
| 3 | MED | \`\${{ inputs.version }}\` interpolated into 5 shell blocks | Moved to \`env:\` |
| 4 | LOW | Self-referential npm dep \`"agentsys": "^5.0.0"\` | Removed |

## Marketplace pin status

- **Tag+SHA pinned**: next-task (v1.1.1), repo-intel (v0.2.0), onboard (v0.1.0), can-i-help (v0.1.0)
- **SHA-only pinned** (no matching \`v<version>\` tag on remote): 16 plugins including agnix, ship, prepare-delivery, web-ctl, etc.

Once each sub-plugin cuts a proper \`v<version>\` tag, re-run \`node scripts/pin-marketplace.js\` to upgrade SHA pins to tag+SHA pins.

## Test plan

- \`node -e "JSON.parse(...)"\` marketplace.json — valid
- \`js-yaml.load\` for ci.yml + release.yml — valid
- No test suite present (pre-existing)

## Follow-up

- After agent-analyzer/agnix/web-ctl land their security releases and cut tags, re-run \`pin-marketplace.js\` and ship agentsys v5.10.0 with upgraded pins.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how marketplace plugins and reusable workflows are sourced (tag/SHA pinning) and tweaks release workflow shell variable handling, which could affect CI/release behavior if pins or env wiring are wrong.
> 
> **Overview**
> **Hardens supply-chain integrity for plugin installs and CI.** Marketplace `source: "url"` entries in `.claude-plugin/marketplace.json` are now pinned to immutable refs by adding `commit` SHAs (and `ref` tags when available) instead of tracking default branches.
> 
> Adds `scripts/pin-marketplace.js` to automatically resolve `v<version>` tags to SHAs via `gh`, falling back to `main`’s HEAD SHA when no tag exists.
> 
> **Locks down GitHub Actions usage.** The reusable `agnix` workflow in `ci.yml` is SHA-pinned, and `release.yml` stops interpolating `${{ inputs.* }}` directly in shell blocks by passing values via `env` variables. Also removes the self-referential `agentsys` dependency from `package.json`/`package-lock.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 604bb169e0ad96b60cfb0d5a9bb1bc971315349d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->