### PR TITLE
Integrate Axiom plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "description": "20 specialized plugins for AI workflow automation - task orchestration, PR workflow, slop detection, code review, drift detection, enhancement analysis, documentation sync, unified static analysis, perf investigations, topic research, agent config linting, cross-tool AI consultation, structured AI debate, workflow pattern learning, codebase onboarding, contributor guidance, and Zig language support",
+  "description": "21 specialized plugins for AI workflow automation - task orchestration, PR workflow, slop detection, code review, drift detection, enhancement analysis, documentation sync, unified static analysis, durable memory, perf investigations, topic research, agent config linting, cross-tool AI consultation, structured AI debate, workflow pattern learning, codebase onboarding, contributor guidance, and Zig language support",
   "version": "5.12.0",
   "owner": {
     "name": "Avi Fenesh",
@@ -171,6 +171,18 @@
       "version": "1.0.0",
       "category": "productivity",
       "homepage": "https://github.com/agent-sh/learn"
+    },
+    {
+      "name": "axiom",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/agent-sh/axiom.git",
+        "commit": "a1bf0fc9ab61178774b3391a337db3e1af20413a"
+      },
+      "description": "Personal agent-native knowledge base: load thin context, query durable memories, create project scaffolds, and propose approved records",
+      "version": "0.6.0",
+      "category": "productivity",
+      "homepage": "https://github.com/agent-sh/axiom"
     },
     {
       "name": "agnix",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -4,8 +4,8 @@
   "skills": "./adapters/codex/skills",
   "interface": {
     "displayName": "agentsys",
-    "shortDescription": "AI agent orchestration with 42 skills and 50 agents",
-    "longDescription": "Professional-grade slash commands for AI-powered development workflows. Includes /next-task (task discovery to production), /ship (commit to deploy), /audit-project (multi-agent code review), /deslop (AI slop cleanup), /perf (performance investigation), /enhance (config analysis), /consult (cross-tool AI consultation), and more.",
+    "shortDescription": "AI agent orchestration with 42 skills and 49 agents",
+    "longDescription": "Professional-grade slash commands for AI-powered development workflows. Includes /next-task (task discovery to production), /axiom (durable agent memory), /ship (commit to deploy), /audit-project (multi-agent code review), /deslop (AI slop cleanup), /perf (performance investigation), /enhance (config analysis), /consult (cross-tool AI consultation), and more.",
     "developerName": "Avi Fenesh",
     "category": "developer-tools",
     "capabilities": [
@@ -14,12 +14,13 @@
       "ci-cd",
       "deployment",
       "performance",
-      "documentation"
+      "documentation",
+      "memory"
     ],
     "websiteUrl": "https://agent-sh.github.io/agent-sh.dev/",
     "defaultPrompt": [
       "What should I work on next?",
-      "Ship my changes",
+      "Load my durable Axiom context",
       "Review this codebase"
     ]
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@
 <!-- GEN:START:claude-architecture -->
 ```
 lib/          → Shared library (vendored to plugins)
-plugins/      → 0 plugins, 10 agents (0 file-based + 10 role-based), 0 skills
+plugins/      → 21 plugins, 49 agents (39 file-based + 10 role-based), 42 skills
 adapters/     → Platform adapters (opencode-plugin/, opencode/, codex/)
 checklists/   → Action checklists (9 files)
 bin/cli.js    → npm CLI installer
@@ -84,6 +84,27 @@ bin/cli.js    → npm CLI installer
 
 | Plugin | Agents | Skills | Purpose |
 |--------|--------|--------|---------|
+| next-task | 8 | 1 | Master workflow orchestration |
+| prepare-delivery | 3 | 4 | Pre-ship quality gates |
+| gate-and-ship | 0 | 0 | Quality gates then ship |
+| ship | 1 | 1 | PR creation and deployment |
+| deslop | 1 | 1 | AI slop cleanup |
+| audit-project | 10 | 1 | Multi-agent code review |
+| drift-detect | 1 | 1 | Plan drift detection |
+| enhance | 8 | 9 | Code quality analyzers |
+| sync-docs | 1 | 1 | Documentation sync |
+| repo-intel | 1 | 1 | Unified static analysis |
+| axiom | 0 | 1 | Durable agent-native memory |
+| perf | 6 | 8 | Performance investigation |
+| learn | 1 | 1 | Topic research and learning guides |
+| agnix | 1 | 1 | Agent config linting |
+| consult | 1 | 1 | Cross-tool AI consultation |
+| debate | 1 | 1 | Multi-perspective debate analysis |
+| web-ctl | 1 | 2 | Browser automation for AI agents |
+| skillers | 2 | 2 | Workflow pattern learning |
+| onboard | 1 | 1 | Codebase onboarding |
+| can-i-help | 1 | 1 | Contributor guidance |
+| zig-lsp | 0 | 0 |  |
 <!-- GEN:END:claude-architecture -->
 
 **Pattern**: `Command → Agent → Skill` (orchestration → invocation → implementation)
@@ -152,7 +173,7 @@ agentsys                # Run installer
 <agents>
 ## Agents
 
-49 agents across 20 plugins (18 have agents; gate-and-ship is commands-only; zig-lsp is config-only with no commands or agents). Key agents by model:
+49 agents across 21 plugins (18 have agents; gate-and-ship is commands-only; axiom is skill/command-only; zig-lsp is config-only with no commands or agents). Key agents by model:
 
 | Model | Agents | Use Case |
 |-------|--------|----------|
@@ -166,7 +187,7 @@ See [README.md](./README.md#command-details) and [docs/reference/AGENTS.md](./do
 <skills>
 ## Skills
 
-40 skills across plugins. Agents invoke skills for reusable implementation.
+42 skills across plugins. Agents invoke skills for reusable implementation.
 
 | Category | Key Skills |
 |----------|------------|
@@ -174,6 +195,7 @@ See [README.md](./README.md#command-details) and [docs/reference/AGENTS.md](./do
 | Enhancement | `enhance-*` (9 skills for plugins, agents, docs, prompts, hooks) |
 | Performance | `baseline`, `benchmark`, `profile`, `theory-tester` |
 | Cleanup | `deslop`, `sync-docs`, `drift-analysis`, `repo-intel` |
+| Memory | `axiom` |
 
 See [README.md](./README.md#skills) for full skill list.
 </skills>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added the `axiom` plugin to the agentsys marketplace and static docs metadata. Axiom provides durable agent-native memory, project context loading, scoped querying, project scaffolding, and human-approved record proposals.
+
 ## [5.12.0] - 2026-04-26
 
 ### Propagated upstream releases

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <b>20 plugins · 49 agents · 41 skills (across all repos) · 30k lines of lib code · 3,507 tests · 5 platforms</b><br>
+  <b>21 plugins · 49 agents · 42 skills (across all repos) · 30k lines of lib code · 3,513 tests · 5 platforms</b><br>
   <em>Plugins distributed as standalone repos under <a href="https://github.com/agent-sh">agent-sh</a> org - agentsys is the marketplace &amp; installer</em>
 </p>
 
@@ -45,7 +45,7 @@ AI models can write code. That's not the hard part anymore. The hard part is eve
 
 ## What This Is
 
-An agent orchestration system - 20 plugins, 49 agents (39 file-based + 10 role-based specialists in audit-project), and 41 skills that compose into structured pipelines for software development. Each plugin lives in its own standalone repo under the [agent-sh](https://github.com/agent-sh) org. agentsys is the marketplace and installer that ties them together.
+An agent orchestration system - 21 plugins, 49 agents (39 file-based + 10 role-based specialists in audit-project), and 42 skills that compose into structured pipelines for software development. Each plugin lives in its own standalone repo under the [agent-sh](https://github.com/agent-sh) org. agentsys is the marketplace and installer that ties them together.
 
 Each agent has a single responsibility, a specific model assignment, and defined inputs/outputs. Pipelines enforce phase gates so agents can't skip steps. State persists across sessions so work survives interruptions.
 
@@ -118,6 +118,7 @@ The investment shifts from model spend to pipeline design. Better prompts, riche
 | [`/next-task`](#next-task) | Task workflow: discovery, implementation, PR, merge |
 | [`/prepare-delivery`](#prepare-delivery) | Pre-ship quality gates: deslop, review, validation, docs sync |
 | [`/gate-and-ship`](#gate-and-ship) | Quality gates then ship (/prepare-delivery + /ship) |
+| [`/axiom`](#axiom) | Durable memory: load, query, list, bootstrap projects, and record approved knowledge |
 | [`/agnix`](#agnix) | Lint agent configurations (399 rules) |
 | [`/ship`](#ship) | PR creation, CI monitoring, merge |
 | [`/deslop`](#deslop) | Clean AI slop patterns |
@@ -142,7 +143,7 @@ Each command works standalone. Together, they compose into end-to-end pipelines.
 
 ## Skills
 
-41 skills included across the plugins:
+42 skills included across the plugins:
 
 | Category | Skills |
 |----------|--------|
@@ -157,6 +158,7 @@ Each command works standalone. Together, they compose into end-to-end pipelines.
 | **Web** | `web-auth`, `web-browse` |
 | **Release** | `release` |
 | **Analysis** | `drift-analysis`, `repo-intel` |
+| **Memory** | `axiom` |
 | **Linting** | `agnix` |
 
 **External skill plugins** (standalone repos, installed separately):
@@ -175,8 +177,8 @@ Skills are the reusable implementation units. Agents invoke skills; commands orc
 |---------|--------------|
 | [The Approach](#the-approach) | Why it's built this way |
 | [Benchmarks](#benchmarks) | Sonnet + agentsys vs raw Opus |
-| [Commands](#commands) | All 20 commands overview |
-| [Skills](#skills) | 41 skills across plugins |
+| [Commands](#commands) | All 21 commands overview |
+| [Skills](#skills) | 42 skills across plugins |
 | [Skill-Only Plugins](#skill-only-plugins) | glide-mq and other non-command plugins |
 | [Command Details](#command-details) | Deep dive into each command |
 | [How Commands Work Together](#how-commands-work-together) | Standalone vs integrated |
@@ -304,6 +306,35 @@ Does NOT create PRs or push - use `/ship` or `/gate-and-ship` after.
 ```
 
 Each piece runs independently - use `/prepare-delivery` alone to review before deciding to ship, or `/ship` alone if already validated.
+
+---
+
+### /axiom
+
+**Purpose:** Durable, queryable memory for agents. Load the smallest useful context, query project or global knowledge, and propose new records without bloating `AGENTS.md`.
+
+**[axiom](https://github.com/agent-sh/axiom)** is a standalone plugin and CLI. It creates a private `axiom-based` knowledge repo after explicit approval, keeps only thin context loaded automatically, and stores durable decisions, memories, preferences, and project notes in queryable files.
+
+**What it does:**
+
+| Command | Use |
+|---------|-----|
+| `axiom before-any --quiet` | Load global thin context at the start of meaningful work |
+| `axiom before-any --project <slug>` | Load project context and create missing project scaffolds |
+| `axiom query "<keyword>" --project <slug>` | Retrieve focused, source-backed project knowledge |
+| `axiom list --topics --project <slug>` | Explore what knowledge exists before querying |
+| `axiom record ...` | Propose a durable record through a temp clone, diff, and human approval |
+
+**Usage:**
+
+```bash
+/axiom before-any --quiet
+/axiom before-any --project flowfabric
+/axiom query "lease based" --project flowfabric
+/axiom record --project flowfabric --kind decision "Lease-based claiming v2" "We switched because it gives stronger safety during restarts."
+```
+
+**External tool:** Requires the [axiom CLI](https://github.com/agent-sh/axiom) from the plugin package.
 
 ---
 
@@ -1237,7 +1268,7 @@ The system is built on research, not guesswork.
 - Instruction following reliability
 
 **Testing:**
-- 3,507 tests passing
+- 3,513 tests passing
 - Drift-detect validated on 1,000+ repositories
 - E2E workflow testing across all commands
 - Cross-platform validation (Claude Code, OpenCode, Codex CLI, Cursor, Kiro)

--- a/__tests__/generate-docs.test.js
+++ b/__tests__/generate-docs.test.js
@@ -118,11 +118,19 @@ describe('generate-docs', () => {
       const agents = discovery.discoverAgents(REPO_ROOT);
       const skills = discovery.discoverSkills(REPO_ROOT);
       const table = genDocs.generateArchitectureTable(plugins, agents, skills);
-      const totalAgents = agents.length + genDocs.ROLE_BASED_AGENT_COUNT;
-      expect(table).toContain(`${plugins.length} plugins`);
-      expect(table).toContain(`${totalAgents} agents`);
-      expect(table).toContain(`${agents.length} file-based`);
-      expect(table).toContain(`${skills.length} skills`);
+      const expectedPlugins = plugins.length > 0 ? plugins.length : genDocs.STATIC_PLUGIN_COUNT;
+      const expectedFileBasedAgents = agents.length > 0
+        ? agents.length
+        : genDocs.STATIC_FILE_BASED_AGENT_COUNT;
+      const expectedTotalAgents = agents.length > 0
+        ? agents.length + genDocs.ROLE_BASED_AGENT_COUNT
+        : genDocs.STATIC_AGENT_COUNT;
+      const expectedSkills = skills.length > 0 ? skills.length : STATIC_SKILLS.length;
+
+      expect(table).toContain(`${expectedPlugins} plugins`);
+      expect(table).toContain(`${expectedTotalAgents} agents`);
+      expect(table).toContain(`${expectedFileBasedAgents} file-based`);
+      expect(table).toContain(`${expectedSkills} skills`);
     });
 
     test('lists all plugins', () => {

--- a/__tests__/repo-map-installer.test.js
+++ b/__tests__/repo-map-installer.test.js
@@ -5,6 +5,13 @@
  * It now delegates to the binary module for auto-download.
  */
 
+jest.mock('../lib/binary', () => ({
+  isAvailable: jest.fn(() => true),
+  getVersion: jest.fn(() => '0.3.0'),
+  ensureBinary: jest.fn(async () => {}),
+  ensureBinarySync: jest.fn(() => {})
+}));
+
 const {
   checkInstalled,
   checkInstalledSync,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,11 +73,11 @@ agentsys/
     ├── KNOWLEDGE-LIBRARY.md      # Index
     └── *-REFERENCE.md            # Research documents
 
-NOTE: plugins/ has been removed. All 20 plugins are now standalone repos
+NOTE: plugins/ has been removed. All 21 plugins are now standalone repos
 under the agent-sh org. The installer fetches them from GitHub at install time.
 Plugin repos: agent-sh/{next-task,prepare-delivery,gate-and-ship,ship,deslop,
               audit-project,enhance,perf,drift-detect,sync-docs,repo-intel,
-              learn,consult,debate,agnix,web-ctl,skillers,onboard,can-i-help,
+              axiom,learn,consult,debate,agnix,web-ctl,skillers,onboard,can-i-help,
               zig-lsp}
 ```
 
@@ -136,6 +136,7 @@ The package provides these capabilities through commands, agents, and skills:
 | Documentation | `/sync-docs` | Sync docs with code changes |
 | Drift detection | `/drift-detect` | Plan vs implementation analysis |
 | Code review | `/audit-project` | Multi-agent code review |
+| Durable memory | `/axiom` | Load, query, and record agent-native context |
 | Config linting | `/agnix` | Lint agent configurations (385 rules) |
 | Research | `/learn` | Research topics, create learning guides |
 | AI consultation | `/consult` | Cross-tool AI consultation |
@@ -165,7 +166,7 @@ agentsys  # Select option 1
 
 **Location:** `~/.claude/plugins/agentsys/`
 
-**Commands:** `/next-task`, `/prepare-delivery`, `/gate-and-ship`, `/ship`, `/release`, `/deslop`, `/audit-project`, `/drift-detect`, `/repo-intel`, `/enhance`, `/perf`, `/sync-docs`, `/agnix`, `/learn`, `/consult`, `/debate`, `/web-ctl`, `/skillers`, `/onboard`, `/can-i-help`
+**Commands:** `/next-task`, `/prepare-delivery`, `/gate-and-ship`, `/ship`, `/release`, `/deslop`, `/audit-project`, `/drift-detect`, `/repo-intel`, `/enhance`, `/perf`, `/sync-docs`, `/axiom`, `/agnix`, `/learn`, `/consult`, `/debate`, `/web-ctl`, `/skillers`, `/onboard`, `/can-i-help`
 
 ### OpenCode
 
@@ -179,7 +180,7 @@ agentsys  # Select option 2
 - Skills: `~/.config/opencode/skills/`
 - Native plugin: `~/.config/opencode/plugins/agentsys.ts`
 
-**Commands:** `/next-task`, `/prepare-delivery`, `/gate-and-ship`, `/ship`, `/release`, `/deslop`, `/audit-project`, `/drift-detect`, `/repo-intel`, `/enhance`, `/perf`, `/sync-docs`, `/agnix`, `/learn`, `/consult`, `/debate`, `/web-ctl`, `/skillers`, `/onboard`, `/can-i-help`
+**Commands:** `/next-task`, `/prepare-delivery`, `/gate-and-ship`, `/ship`, `/release`, `/deslop`, `/audit-project`, `/drift-detect`, `/repo-intel`, `/enhance`, `/perf`, `/sync-docs`, `/axiom`, `/agnix`, `/learn`, `/consult`, `/debate`, `/web-ctl`, `/skillers`, `/onboard`, `/can-i-help`
 
 **Native Plugin Features:**
 - Auto-thinking selection per agent
@@ -196,7 +197,7 @@ agentsys  # Select option 3
 - Config: `~/.codex/config.toml`
 - Skills: `~/.codex/skills/`
 
-**Skills:** `$next-task`, `$prepare-delivery`, `$gate-and-ship`, `$ship`, `$release`, `$deslop`, `$audit-project`, `$drift-detect`, `$repo-intel`, `$enhance`, `$perf`, `$sync-docs`, `$agnix`, `$learn`, `$consult`, `$debate`, `$web-ctl`, `$skillers`, `$onboard`, `$can-i-help`
+**Skills:** `$next-task`, `$prepare-delivery`, `$gate-and-ship`, `$ship`, `$release`, `$deslop`, `$audit-project`, `$drift-detect`, `$repo-intel`, `$enhance`, `$perf`, `$sync-docs`, `$axiom`, `$agnix`, `$learn`, `$consult`, `$debate`, `$web-ctl`, `$skillers`, `$onboard`, `$can-i-help`
 
 **Internal skill:** `orchestrate-review` (Phase 9 review pass definitions used by /next-task and /audit-project)
 
@@ -227,6 +228,7 @@ description: Master workflow orchestrator for task-to-production automation
 | `/enhance` | [OK] Full | [OK] Full | [OK] Full | Orchestrates all enhancers |
 | `/perf` | [OK] Full | [OK] Full | [OK] Full | Performance investigations |
 | `/sync-docs` | [OK] Full | [OK] Full | [OK] Full | Documentation sync |
+| `/axiom` | [OK] Full | [OK] Full | [OK] Full | Durable memory; requires `axiom` CLI |
 | `/agnix` | [OK] Full | [OK] Full | [OK] Full | Requires `agnix` CLI |
 | `/learn` | [OK] Full | [OK] Full | [OK] Full | Research and learning |
 | `/consult` | [OK] Full | [OK] Full | [OK] Full | Cross-tool consultation |

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -187,7 +187,7 @@ agentsys --tool opencode --no-strip
 ```
 
 This installs:
-- Slash commands (`/next-task`, `/prepare-delivery`, `/gate-and-ship`, `/ship`, `/release`, `/deslop`, `/audit-project`, `/drift-detect`, `/repo-intel`, `/enhance`, `/sync-docs`, `/perf`, `/learn`, `/agnix`, `/consult`, `/debate`, `/web-ctl`, `/skillers`, `/onboard`, `/can-i-help`)
+- Slash commands (`/next-task`, `/prepare-delivery`, `/gate-and-ship`, `/ship`, `/release`, `/deslop`, `/audit-project`, `/drift-detect`, `/repo-intel`, `/enhance`, `/sync-docs`, `/perf`, `/axiom`, `/learn`, `/agnix`, `/consult`, `/debate`, `/web-ctl`, `/skillers`, `/onboard`, `/can-i-help`)
 - **Native OpenCode plugin** with advanced features:
 
 ### Native Plugin Features
@@ -268,7 +268,7 @@ agentsys  # Select option 3 for Codex CLI
 agentsys --tool codex
 ```
 
-This installs skills to `~/.codex/skills/` (`$next-task`, `$prepare-delivery`, `$gate-and-ship`, `$ship`, `$release`, `$deslop`, `$audit-project`, `$drift-detect`, `$repo-intel`, `$enhance`, `$sync-docs`, `$perf`, `$learn`, `$agnix`, `$consult`, `$debate`, `$web-ctl`, `$skillers`, `$onboard`, `$can-i-help`).
+This installs skills to `~/.codex/skills/` (`$next-task`, `$prepare-delivery`, `$gate-and-ship`, `$ship`, `$release`, `$deslop`, `$audit-project`, `$drift-detect`, `$repo-intel`, `$enhance`, `$sync-docs`, `$perf`, `$axiom`, `$learn`, `$agnix`, `$consult`, `$debate`, `$web-ctl`, `$skillers`, `$onboard`, `$can-i-help`).
 
 ### Option 2: Custom Skills
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -32,6 +32,7 @@ Add the marketplace and install plugins directly in Claude Code:
 /plugin install enhance@agentsys
 /plugin install perf@agentsys
 /plugin install sync-docs@agentsys
+/plugin install axiom@agentsys
 /plugin install learn@agentsys
 /plugin install consult@agentsys
 /plugin install debate@agentsys
@@ -188,6 +189,7 @@ You should see commands:
 - `/enhance` - Enhancement analyzer suite
 - `/perf` - Performance investigation workflow
 - `/sync-docs` - Documentation sync
+- `/axiom` - Durable agent-native memory and project context
 - `/learn` - Topic research and learning guides
 - `/consult` - Cross-tool AI consultation
 - `/debate` - Structured AI dialectic with verdict

--- a/docs/ORG_ARCHITECTURE.md
+++ b/docs/ORG_ARCHITECTURE.md
@@ -22,6 +22,7 @@
 | [drift-detect](https://github.com/agent-sh/drift-detect) | Plan drift detection plugin | Active |
 | [sync-docs](https://github.com/agent-sh/sync-docs) | Documentation sync plugin | Active |
 | [repo-intel](https://github.com/agent-sh/repo-intel) | Unified static analysis plugin | Active |
+| [axiom](https://github.com/agent-sh/axiom) | Durable agent-native memory and project context plugin | Active |
 | [learn](https://github.com/agent-sh/learn) | Topic research and learning guides plugin | Active |
 | [consult](https://github.com/agent-sh/consult) | Cross-tool AI consultation plugin | Active |
 | [debate](https://github.com/agent-sh/debate) | Multi-perspective debate analysis plugin | Active |
@@ -105,6 +106,7 @@
 
 **Post-extraction additions:**
 - [x] `zig-lsp` registered as 20th plugin (born standalone, not extracted; LSP plugin distributed via Claude Code marketplace mechanism)
+- [x] `axiom` registered as 21st plugin (born standalone; CLI + skill distributed through the marketplace)
 - [ ] agent-core sync pipeline extended to `zig-lsp` (config-only plugin; sync surface is smaller — likely just CLAUDE.md/AGENTS.md mirror enforcement)
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,7 @@ AgentSys is a modular runtime and orchestration system for AI agents. These docs
 | `/perf` | Performance investigation workflow |
 | `/enhance` | Analyze prompts, plugins, agents, docs, hooks, skills |
 | `/sync-docs` | Sync docs with code changes |
+| `/axiom` | Durable agent-native memory |
 | `/learn` | Research topics online, create learning guides |
 | `/consult` | Cross-tool AI consultation |
 | `/debate` | Structured multi-round debate between AI tools |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -32,6 +32,7 @@ You shouldn't have to repeat the same requests every session. These commands han
 | `/enhance` | Analyze prompts, plugins, agents, docs, hooks, skills | Quality improvement |
 | `/sync-docs` | Sync docs with code changes | Documentation sync |
 | `/perf` | Performance investigation workflow | Baselines, profiling, evidence |
+| `/axiom` | Durable agent-native memory | Load, query, and record project context |
 | `/learn` | Research topics online, create learning guides | Topic research with RAG |
 | `/consult` | Cross-tool AI consultation | Second opinion from other AI tools |
 | `/debate` | Structured multi-round debate between AI tools | AI dialectic with verdict |

--- a/docs/reference/AGENTS.md
+++ b/docs/reference/AGENTS.md
@@ -3,7 +3,7 @@
 Complete reference for all agents in AgentSys.
 
 <!-- GEN:START:agents-counts -->
-**TL;DR:** 49 agents across 20 plugins (18 have agents). opus for reasoning, sonnet for patterns, haiku for execution. Each agent does one thing well. <!-- AGENT_COUNT_TOTAL: 49 -->
+**TL;DR:** 49 agents across 21 plugins (18 have agents). opus for reasoning, sonnet for patterns, haiku for execution. Each agent does one thing well. <!-- AGENT_COUNT_TOTAL: 49 -->
 <!-- GEN:END:agents-counts -->
 
 ---
@@ -24,7 +24,7 @@ Complete reference for all agents in AgentSys.
 
 ## Overview
 
-AgentSys uses 49 specialized agents across 20 plugins (18 have agents; gate-and-ship is commands-only; zig-lsp is a config-only LSP plugin with no commands or agents). Each agent is optimized for a specific task and assigned a model based on complexity:
+AgentSys uses 49 specialized agents across 21 plugins (18 have agents; gate-and-ship is commands-only, axiom is skill/command-only, and zig-lsp is a config-only LSP plugin with no commands or agents). Each agent is optimized for a specific task and assigned a model based on complexity:
 
 | Model | Use Case | Cost |
 |-------|----------|------|

--- a/package-lock.json
+++ b/package-lock.json
@@ -1265,9 +1265,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -55,6 +55,7 @@ const CATEGORY_MAP = {
   'sync-docs': 'Cleanup',
   'drift-detect': 'Analysis',
   'repo-intel': 'Analysis',
+  'axiom': 'Memory',
   'learn': 'AI Collaboration',
   'agnix': 'Linting',
   'consult': 'AI Collaboration',
@@ -96,6 +97,7 @@ const STATIC_SKILLS = [
   { plugin: 'sync-docs', name: 'sync-docs' },
   { plugin: 'drift-detect', name: 'drift-analysis' },
   { plugin: 'repo-intel', name: 'repo-intel' },
+  { plugin: 'axiom', name: 'axiom' },
   { plugin: 'consult', name: 'consult' },
   { plugin: 'debate', name: 'debate' },
   { plugin: 'learn', name: 'learn' },
@@ -126,6 +128,7 @@ const PURPOSE_MAP = {
   'drift-detect': 'Plan drift detection',
   'repo-intel': 'Unified static analysis',
   'sync-docs': 'Documentation sync',
+  'axiom': 'Durable agent-native memory',
   'learn': 'Topic research and learning guides',
   'agnix': 'Agent config linting',
   'consult': 'Cross-tool AI consultation',
@@ -181,7 +184,7 @@ function generateCommandsTable(commands) {
   // Curated display order (featured commands first, then alphabetical)
   const COMMAND_ORDER = [
     'next-task', 'prepare-delivery', 'gate-and-ship',
-    'agnix', 'ship', 'deslop', 'perf',
+    'axiom', 'agnix', 'ship', 'deslop', 'perf',
     'drift-detect', 'audit-project', 'enhance',
     'repo-intel', 'sync-docs', 'learn', 'consult',
     'debate', 'web-ctl', 'release', 'skillers',
@@ -193,6 +196,7 @@ function generateCommandsTable(commands) {
     'next-task': 'Task workflow: discovery, implementation, PR, merge',
     'prepare-delivery': 'Pre-ship quality gates: deslop, review, validation, docs sync',
     'gate-and-ship': 'Quality gates then ship (/prepare-delivery + /ship)',
+    'axiom': 'Durable memory: load, query, list, bootstrap projects, and record approved knowledge',
     'agnix': 'Lint agent configurations (399 rules)',
     'ship': 'PR creation, CI monitoring, merge',
     'deslop': 'Clean AI slop patterns',
@@ -267,7 +271,7 @@ function generateSkillsTable(skills) {
   const categoryOrder = [
     'Workflow', 'Message Queues', 'Enhancement', 'Performance', 'Cleanup',
     'Code Review', 'AI Collaboration', 'Onboarding',
-    'Web', 'Release', 'Analysis', 'Linting', 'Other'
+    'Web', 'Release', 'Analysis', 'Memory', 'Linting', 'Other'
   ];
 
   const lines = [
@@ -289,28 +293,36 @@ function generateSkillsTable(skills) {
  * Generate the architecture table for CLAUDE.md / AGENTS.md.
  */
 function generateArchitectureTable(plugins, agents, skills) {
-  const fileBasedAgents = agents.length;
-  const totalAgents = fileBasedAgents + ROLE_BASED_AGENT_COUNT;
-  const totalSkills = skills.length;
+  const effectivePlugins = plugins.length > 0 ? plugins : Object.keys(STATIC_PLUGIN_AGENT_COUNTS);
+  const effectiveSkills = skills.length > 0 ? skills : STATIC_SKILLS;
+  const fileBasedAgents = agents.length > 0 ? agents.length : STATIC_FILE_BASED_AGENT_COUNT;
+  const totalAgents = agents.length > 0
+    ? fileBasedAgents + ROLE_BASED_AGENT_COUNT
+    : STATIC_AGENT_COUNT;
+  const totalSkills = effectiveSkills.length;
 
   // Count agents per plugin (file-based only)
   const agentsByPlugin = {};
-  for (const agent of agents) {
-    agentsByPlugin[agent.plugin] = (agentsByPlugin[agent.plugin] || 0) + 1;
+  if (agents.length > 0) {
+    for (const agent of agents) {
+      agentsByPlugin[agent.plugin] = (agentsByPlugin[agent.plugin] || 0) + 1;
+    }
+  } else {
+    Object.assign(agentsByPlugin, STATIC_PLUGIN_AGENT_COUNTS);
   }
   // audit-project has role-based agents
   agentsByPlugin['audit-project'] = (agentsByPlugin['audit-project'] || 0) + ROLE_BASED_AGENT_COUNT;
 
   // Count skills per plugin
   const skillsByPlugin = {};
-  for (const skill of skills) {
+  for (const skill of effectiveSkills) {
     skillsByPlugin[skill.plugin] = (skillsByPlugin[skill.plugin] || 0) + 1;
   }
 
   const lines = [
     '```',
     'lib/          \u2192 Shared library (vendored to plugins)',
-    `plugins/      \u2192 ${plugins.length} plugins, ${totalAgents} agents (${fileBasedAgents} file-based + ${ROLE_BASED_AGENT_COUNT} role-based), ${totalSkills} skills`,
+    `plugins/      \u2192 ${effectivePlugins.length} plugins, ${totalAgents} agents (${fileBasedAgents} file-based + ${ROLE_BASED_AGENT_COUNT} role-based), ${totalSkills} skills`,
     'adapters/     \u2192 Platform adapters (opencode-plugin/, opencode/, codex/)',
     'checklists/   \u2192 Action checklists (9 files)',
     'bin/cli.js    \u2192 npm CLI installer',
@@ -320,7 +332,7 @@ function generateArchitectureTable(plugins, agents, skills) {
     '|--------|--------|--------|---------|'
   ];
 
-  for (const plugin of plugins) {
+  for (const plugin of effectivePlugins) {
     const agentCount = agentsByPlugin[plugin] || 0;
     const skillCount = skillsByPlugin[plugin] || 0;
     const purpose = PURPOSE_MAP[plugin] || '';
@@ -421,6 +433,7 @@ const STATIC_PLUGIN_AGENT_COUNTS = {
   'enhance': 8,
   'sync-docs': 1,
   'repo-intel': 1,
+  'axiom': 0,
   'perf': 6,
   'learn': 1,
   'agnix': 1,

--- a/scripts/plugins.txt
+++ b/scripts/plugins.txt
@@ -1,4 +1,5 @@
 agnix
+axiom
 audit-project
 can-i-help
 consult

--- a/site/content.json
+++ b/site/content.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "agentsys",
-    "description": "A modular runtime and orchestration system for AI agents. 20 plugins, 49 agents, 41 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.",
+    "description": "A modular runtime and orchestration system for AI agents. 21 plugins, 49 agents, 42 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.",
     "url": "https://agent-sh.github.io/agentsys",
     "repo": "https://github.com/agent-sh/agentsys",
     "npm": "https://www.npmjs.com/package/agentsys",
@@ -23,7 +23,7 @@
   },
   "stats": [
     {
-      "value": "20",
+      "value": "21",
       "label": "Plugins",
       "suffix": ""
     },
@@ -33,7 +33,7 @@
       "suffix": ""
     },
     {
-      "value": "41",
+      "value": "42",
       "label": "Skills",
       "suffix": ""
     },
@@ -43,7 +43,7 @@
       "suffix": ""
     },
     {
-      "value": "3,507",
+      "value": "3,513",
       "label": "Tests",
       "suffix": ""
     },
@@ -107,6 +107,13 @@
       "tagline": "Quality gates then ship",
       "description": "Quality gates then ship - chains /prepare-delivery then /ship",
       "example": "/gate-and-ship",
+      "category": "workflow"
+    },
+    {
+      "name": "/axiom",
+      "tagline": "Durable memory for agents",
+      "description": "Load thin context, query project or global knowledge, create missing project scaffolds, and propose human-approved records in a private axiom-based knowledge repo.",
+      "example": "/axiom before-any --project flowfabric",
       "category": "workflow"
     },
     {
@@ -531,7 +538,7 @@
   ],
   "research": {
     "knowledge_base": "8,000 lines of curated documentation from Anthropic, OpenAI, Google, and Microsoft",
-    "testing": "3,507 tests passing",
+    "testing": "3,513 tests passing",
     "drift_detect_repos": "1,000+ repositories validated",
     "token_reduction": "77% fewer tokens for drift-detect vs multi-agent approaches"
   },

--- a/site/index.html
+++ b/site/index.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>AgentSys - Agent Runtime &amp; Orchestration System</title>
-  <meta name="description" content="A modular runtime and orchestration system for AI agents. 20 plugins, 49 agents, 41 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
+  <meta name="description" content="A modular runtime and orchestration system for AI agents. 21 plugins, 49 agents, 42 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
   <meta name="theme-color" content="#09090b">
 
   <!-- Open Graph -->
   <meta property="og:title" content="AgentSys">
-  <meta property="og:description" content="A modular runtime and orchestration system for AI agents. 20 plugins, 49 agents, 41 skills.">
+  <meta property="og:description" content="A modular runtime and orchestration system for AI agents. 21 plugins, 49 agents, 42 skills.">
   <meta property="og:image" content="https://agent-sh.github.io/agentsys/assets/logo.png">
   <meta property="og:url" content="https://agent-sh.github.io/agentsys/">
   <meta property="og:type" content="website">
@@ -17,7 +17,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="AgentSys">
-  <meta name="twitter:description" content="AI workflow automation. 20 plugins, 49 agents, 41 skills.">
+  <meta name="twitter:description" content="AI workflow automation. 21 plugins, 49 agents, 42 skills.">
   <meta name="twitter:image" content="https://agent-sh.github.io/agentsys/assets/logo.png">
 
   <!-- Content Security Policy -->
@@ -107,14 +107,14 @@
       <div class="hero__inner">
         <div class="hero__content">
           <div class="hero__badge anim-fade-in" data-delay="100">
-            20 plugins &middot; 49 agents &middot; 41 skills
+            21 plugins &middot; 49 agents &middot; 42 skills
           </div>
           <h1 class="hero__title anim-fade-up" id="hero-title" data-delay="200">
             A modular <span class="text-gradient">runtime and orchestration system</span><br>
             for AI agents.
           </h1>
           <p class="hero__subtitle anim-fade-up" data-delay="350">
-            Structured pipelines, gated phases, specialized agents. Works with Claude Code, OpenCode, Codex CLI, Cursor, and Kiro. 3,507 tests. Production-grade.
+            Structured pipelines, gated phases, specialized agents. Works with Claude Code, OpenCode, Codex CLI, Cursor, and Kiro. 3,513 tests. Production-grade.
           </p>
           <div class="hero__ctas anim-fade-up" data-delay="500">
             <a href="#install" class="btn btn--primary">Get Started</a>
@@ -156,7 +156,7 @@
     <section class="stats" id="stats" aria-label="Project statistics">
       <div class="stats__inner">
         <div class="stats__item">
-          <span class="stats__number" aria-live="polite" data-target="20">0</span>
+          <span class="stats__number" aria-live="polite" data-target="21">0</span>
           <span class="stats__label">Plugins</span>
         </div>
         <div class="stats__item">
@@ -164,11 +164,11 @@
           <span class="stats__label">Agents</span>
         </div>
         <div class="stats__item">
-          <span class="stats__number" aria-live="polite" data-target="41">0</span>
+          <span class="stats__number" aria-live="polite" data-target="42">0</span>
           <span class="stats__label">Skills</span>
         </div>
         <div class="stats__item">
-          <span class="stats__number" aria-live="polite" data-target="3507">0</span>
+          <span class="stats__number" aria-live="polite" data-target="3513">0</span>
           <span class="stats__label">Tests Passing</span>
         </div>
       </div>
@@ -177,7 +177,7 @@
     <!-- ===== COMMANDS ===== -->
     <section class="commands" id="commands" aria-labelledby="commands-title">
       <div class="commands__inner">
-        <h2 class="commands__title anim-fade-up" id="commands-title">20 Commands. One Toolkit.</h2>
+        <h2 class="commands__title anim-fade-up" id="commands-title">21 Commands. One Toolkit.</h2>
         <p class="commands__subtitle anim-fade-up" data-delay="100">Each works standalone. Together, they automate everything.</p>
 
         <div class="commands__tabs anim-fade-up" data-delay="200">
@@ -202,6 +202,7 @@
             <button class="tabs__tab" role="tab" aria-selected="false" aria-controls="tab-panel-17" id="tab-17" tabindex="-1" data-index="17">/skillers</button>
             <button class="tabs__tab" role="tab" aria-selected="false" aria-controls="tab-panel-18" id="tab-18" tabindex="-1" data-index="18">/onboard</button>
             <button class="tabs__tab" role="tab" aria-selected="false" aria-controls="tab-panel-19" id="tab-19" tabindex="-1" data-index="19">/can-i-help</button>
+            <button class="tabs__tab" role="tab" aria-selected="false" aria-controls="tab-panel-20" id="tab-20" tabindex="-1" data-index="20">/axiom</button>
           </div>
 
           <!-- Tab panels -->
@@ -584,6 +585,25 @@
 <span class="code-prompt">$</span> /can-i-help --skills=typescript  <span class="code-comment"># Match specific skills</span></code></pre>
             </div>
           </div>
+
+          <div class="tabs__panel" role="tabpanel" id="tab-panel-20" aria-labelledby="tab-20" hidden>
+            <h3 class="tabs__panel-name">/axiom</h3>
+            <p class="tabs__panel-tagline">Durable memory for agents</p>
+            <ul class="tabs__panel-features">
+              <li>Loads thin global and project context</li>
+              <li>Queries durable decisions, memories, and preferences</li>
+              <li>Creates missing project scaffolds automatically</li>
+              <li>Records only through a diff and human approval</li>
+            </ul>
+            <div class="code-block">
+              <button class="code-block__copy" aria-label="Copy code to clipboard" data-code="/axiom before-any --project flowfabric
+/axiom query &quot;lease based&quot; --project flowfabric">
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"/><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"/></svg>
+              </button>
+              <pre><code><span class="code-prompt">$</span> /axiom before-any --project flowfabric
+<span class="code-prompt">$</span> /axiom query "lease based" --project flowfabric</code></pre>
+            </div>
+          </div>
         </div>
       </div>
     </section>
@@ -662,7 +682,7 @@
     <!-- ===== AGENTS & SKILLS ===== -->
     <section class="agents-skills" id="agents-skills" aria-labelledby="as-title">
       <div class="agents-skills__inner">
-        <h2 class="agents-skills__title anim-fade-up" id="as-title">49 Agents. 41 Skills.</h2>
+        <h2 class="agents-skills__title anim-fade-up" id="as-title">49 Agents. 42 Skills.</h2>
         <p class="agents-skills__subtitle anim-fade-up" data-delay="100">Right model for the task. Opus reasons. Sonnet validates. Haiku executes.</p>
 
         <!-- Agent tier tabs -->
@@ -749,7 +769,7 @@
         </div>
 
         <!-- Skills grid -->
-        <h3 class="agents-skills__skills-title anim-fade-up" data-delay="300">41 Skills across 19 Plugins</h3>
+        <h3 class="agents-skills__skills-title anim-fade-up" data-delay="300">42 Skills across 21 Plugins</h3>
         <div class="skills-grid anim-fade-up" data-delay="350">
           <div class="skill-group">
             <span class="skill-group__label">prepare-delivery</span>
@@ -815,6 +835,7 @@
               <span class="skill-card">repo-intel</span>
               <span class="skill-card">sync-docs</span>
               <span class="skill-card">learn</span>
+              <span class="skill-card">axiom</span>
               <span class="skill-card">consult</span>
               <span class="skill-card">debate</span>
               <span class="skill-card">release</span>

--- a/site/ux-spec.md
+++ b/site/ux-spec.md
@@ -94,7 +94,7 @@ Scroll order with rationale for each section. All sections are full-width, alter
 - **Single column on mobile:** Text above, terminal below. Stack with 48px gap.
 
 ### Left Column Content
-1. **Badge** (top, above title): Small pill showing version or "20 plugins . 49 agents . 41 skills"
+1. **Badge** (top, above title): Small pill showing version or "21 plugins . 49 agents . 42 skills"
    - Background: `rgba(99, 102, 241, 0.12)`, border: `1px solid rgba(99, 102, 241, 0.25)`, border-radius: 9999px
    - Font: 13px, font-weight 500, primary accent color
    - Padding: 4px 14px
@@ -104,7 +104,7 @@ Scroll order with rationale for each section. All sections are full-width, alter
    - Color: white
    - "entire dev workflow" portion highlighted with a subtle gradient text (primary-to-secondary accent via `background-clip: text`)
 
-3. **Subtitle:** "20 plugins, 49 agents, 41 skills. From task selection to merged PR. Works with Claude Code, OpenCode, Codex CLI, Cursor, and Kiro."
+3. **Subtitle:** "21 plugins, 49 agents, 42 skills. From task selection to merged PR. Works with Claude Code, OpenCode, Codex CLI, Cursor, and Kiro."
    - Font: 18px on desktop, 16px on mobile, font-weight 400, line-height 1.6
    - Color: `rgba(255, 255, 255, 0.6)`
    - Max-width: 520px
@@ -229,7 +229,7 @@ Done. Task to merged PR in 12 minutes.
 | 1 | 20 | Plugins |
 | 2 | 49 | Agents |
 | 3 | 41 | Skills |
-| 4 | 3,507 | Tests Passing |
+| 4 | 3,513 | Tests Passing |
 
 ### Styling
 - **Number:** 48px, font-weight 700, white, `font-variant-numeric: tabular-nums` (prevents layout shift during count)
@@ -265,7 +265,7 @@ Done. Task to merged PR in 12 minutes.
   - On mobile: naturally scrollable, slight gradient fade on right edge to indicate scrollability (20px gradient from transparent to section background)
 
 ### Tab Order
-`/next-task`, `/ship`, `/deslop`, `/perf`, `/drift-detect`, `/audit-project`, `/enhance`, `/repo-intel`, `/sync-docs`, `/learn`, `/agnix`
+`/next-task`, `/ship`, `/deslop`, `/perf`, `/drift-detect`, `/audit-project`, `/enhance`, `/repo-intel`, `/sync-docs`, `/axiom`, `/learn`, `/agnix`
 
 (Most impactful first: the full workflow command, then the shipper, then individual tools)
 
@@ -650,13 +650,13 @@ This disables:
 ### Head Content
 ```html
 <title>AgentSys - Agent Runtime &amp; Orchestration System</title>
-<meta name="description" content="A modular runtime and orchestration system for AI agents. 20 plugins, 49 agents, 41 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
+<meta name="description" content="A modular runtime and orchestration system for AI agents. 21 plugins, 49 agents, 42 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="theme-color" content="#0a0a0f">
 
 <!-- Open Graph -->
 <meta property="og:title" content="AgentSys">
-<meta property="og:description" content="AI workflow automation. 20 plugins, 49 agents, 41 skills. Task to merged PR.">
+<meta property="og:description" content="AI workflow automation. 21 plugins, 49 agents, 42 skills. Task to merged PR.">
 <meta property="og:image" content="https://agent-sh.github.io/agentsys/assets/og-image.png">
 <meta property="og:url" content="https://agent-sh.github.io/agentsys/">
 <meta property="og:type" content="website">
@@ -664,7 +664,7 @@ This disables:
 <!-- Twitter Card -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AgentSys">
-<meta name="twitter:description" content="AI workflow automation. 20 plugins, 49 agents, 41 skills.">
+<meta name="twitter:description" content="AI workflow automation. 21 plugins, 49 agents, 42 skills.">
 <meta name="twitter:image" content="https://agent-sh.github.io/agentsys/assets/og-image.png">
 ```
 


### PR DESCRIPTION
## Summary
- Add Axiom to the agentsys marketplace pinned to agent-sh/axiom@a1bf0fc
- Update static plugin/skill/docs/site metadata for 21 plugins, 49 agents, and 42 skills
- Make generated docs fallback to static standalone-plugin metadata and make repo-map installer tests deterministic
- Apply npm audit fix for brace-expansion

## Verification
- npm test
- npm run validate
- npm run gen-docs:check
- npm run preflight
- agnix .
- npm audit --audit-level=moderate
- npm pack --dry-run