### PR TITLE
Release agentsys v5.13.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "agentsys",
   "description": "24 specialized plugins for AI workflow automation - task orchestration, PR workflow, slop detection, code review, drift detection, enhancement analysis, documentation sync, unified static analysis, durable memory, negative behavior memory, skill and system prompt curation, perf investigations, topic research, agent config linting, cross-tool AI consultation, structured AI debate, workflow pattern learning, codebase onboarding, contributor guidance, and Zig language support",
-  "version": "5.13.0",
+  "version": "5.13.1",
   "owner": {
     "name": "Avi Fenesh",
     "url": "https://github.com/avifenesh"
@@ -216,7 +216,7 @@
         "source": "url",
         "url": "https://github.com/agent-sh/banthis.git",
         "ref": "v0.3.0",
-        "commit": "5820a197bba0f01ec4877a63c5d13c108d8c661d"
+        "commit": "06a3c9a893453d080dd49a4d0e9e7bd88d45e631"
       },
       "description": "Durable negative behavior memory: persist user-defined banned agent behaviors into CLAUDE.md or AGENTS.md",
       "version": "0.3.0",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "version": "5.13.0",
+  "version": "5.13.1",
   "description": "Professional-grade slash commands for Claude Code with cross-platform support",
   "keywords": [
     "workflow",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.13.1] - 2026-05-17
+
+### Changed
+- Updated the `banthis` marketplace pin to the GitHub-installable `v0.3.0` commit so documented fallback installation works without npm publication.
+
 ## [5.13.0] - 2026-05-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentsys",
-  "version": "5.13.0",
+  "version": "5.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentsys",
-      "version": "5.13.0",
+      "version": "5.13.1",
       "license": "MIT",
       "workspaces": [
         "lib"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "version": "5.13.0",
+  "version": "5.13.1",
   "description": "A modular runtime and orchestration system for AI agents - works with Claude Code, OpenCode, and Codex CLI",
   "main": "lib/platform/detect-platform.js",
   "type": "commonjs",

--- a/site/content.json
+++ b/site/content.json
@@ -5,7 +5,7 @@
     "url": "https://agent-sh.github.io/agentsys",
     "repo": "https://github.com/agent-sh/agentsys",
     "npm": "https://www.npmjs.com/package/agentsys",
-    "version": "5.13.0",
+    "version": "5.13.1",
     "author": "Avi Fenesh",
     "author_url": "https://github.com/avifenesh"
   },


### PR DESCRIPTION
## Summary
- bump AgentSys to v5.13.1
- update banthis marketplace pin to the corrected GitHub-installable v0.3.0 commit
- document why the patch release exists in the changelog

## Validation
- node scripts/pin-marketplace.js --dry-run
- npm run gen-docs:check
- npm run validate
- agnix .
- npm run preflight:release