### PR TITLE
Release agentsys v5.13.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "agentsys",
   "description": "24 specialized plugins for AI workflow automation - task orchestration, PR workflow, slop detection, code review, drift detection, enhancement analysis, documentation sync, unified static analysis, durable memory, negative behavior memory, skill and system prompt curation, perf investigations, topic research, agent config linting, cross-tool AI consultation, structured AI debate, workflow pattern learning, codebase onboarding, contributor guidance, and Zig language support",
-  "version": "5.13.1",
+  "version": "5.13.2",
   "owner": {
     "name": "Avi Fenesh",
     "url": "https://github.com/avifenesh"
@@ -215,11 +215,11 @@
       "source": {
         "source": "url",
         "url": "https://github.com/agent-sh/banthis.git",
-        "ref": "v0.3.0",
-        "commit": "06a3c9a893453d080dd49a4d0e9e7bd88d45e631"
+        "ref": "v0.3.1",
+        "commit": "197c8f8b2a074ba22791ee04407f60344f5eee7c"
       },
       "description": "Durable negative behavior memory: persist user-defined banned agent behaviors into CLAUDE.md or AGENTS.md",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "category": "productivity",
       "homepage": "https://github.com/agent-sh/banthis"
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "version": "5.13.1",
+  "version": "5.13.2",
   "description": "Professional-grade slash commands for Claude Code with cross-platform support",
   "keywords": [
     "workflow",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.13.2] - 2026-05-17
+
+### Changed
+- Updated the `banthis` marketplace pin to `v0.3.1`, which hardens CLI writes and fixes the init fallback install path.
+
+### Tests
+- Added marketplace contract coverage for the standalone curator and negative-memory plugins.
+
 ## [5.13.1] - 2026-05-17
 
 ### Changed

--- a/__tests__/marketplace-standalone-contract.test.js
+++ b/__tests__/marketplace-standalone-contract.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const marketplace = require('../.claude-plugin/marketplace.json');
+const codexPlugin = require('../.codex-plugin/plugin.json');
+const siteContent = require('../site/content.json');
+
+const repoRoot = path.join(__dirname, '..');
+
+const expectedStandalonePlugins = {
+  'skill-curator': {
+    version: '1.0.0',
+    ref: 'v1.0.0',
+    commit: 'e30ebfe3e7a5307e97fa4e6d59f538b12f8074c5',
+    command: '/skill-curator',
+    category: 'development',
+  },
+  'system-prompt-curator': {
+    version: '2.0.0',
+    ref: 'v2.0.0',
+    commit: '277bee4b8b3b796d2a627132c88fb132479cbde0',
+    command: '/system-prompt-curator',
+    category: 'development',
+  },
+  banthis: {
+    version: '0.3.1',
+    ref: 'v0.3.1',
+    commit: '197c8f8b2a074ba22791ee04407f60344f5eee7c',
+    command: '/banthis',
+    category: 'productivity',
+  },
+};
+
+function pluginByName(name) {
+  return marketplace.plugins.find((plugin) => plugin.name === name);
+}
+
+test('marketplace plugin names are unique and mirrored in plugins.txt', () => {
+  const names = marketplace.plugins.map((plugin) => plugin.name);
+  expect(new Set(names).size).toBe(names.length);
+
+  const pluginsTxt = fs
+    .readFileSync(path.join(repoRoot, 'scripts/plugins.txt'), 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+
+  expect([...pluginsTxt].sort()).toEqual([...names].sort());
+});
+
+test('standalone curator and memory plugins are pinned to immutable release commits', () => {
+  for (const [name, expected] of Object.entries(expectedStandalonePlugins)) {
+    const plugin = pluginByName(name);
+    expect(plugin).toBeTruthy();
+    expect(plugin.version).toBe(expected.version);
+    expect(plugin.category).toBe(expected.category);
+    expect(plugin.homepage).toBe(`https://github.com/agent-sh/${name}`);
+    expect(plugin.source).toEqual({
+      source: 'url',
+      url: `https://github.com/agent-sh/${name}.git`,
+      ref: expected.ref,
+      commit: expected.commit,
+    });
+  }
+});
+
+test('standalone plugins are represented in user-facing docs and Codex metadata', () => {
+  const readme = fs.readFileSync(path.join(repoRoot, 'README.md'), 'utf8');
+  const architecture = fs.readFileSync(path.join(repoRoot, 'docs/ARCHITECTURE.md'), 'utf8');
+  const siteCommands = new Set(siteContent.commands.map((command) => command.name));
+  const codexDescription = codexPlugin.interface.longDescription;
+
+  for (const [name, expected] of Object.entries(expectedStandalonePlugins)) {
+    expect(siteCommands.has(expected.command)).toBe(true);
+    expect(readme).toContain(expected.command);
+    expect(architecture).toContain(expected.command);
+    expect(codexDescription).toContain(expected.command);
+    expect(codexDescription).toContain(name);
+  }
+});
+
+test('all url-sourced marketplace plugins carry a commit pin', () => {
+  for (const plugin of marketplace.plugins) {
+    if (plugin.source?.source !== 'url') continue;
+
+    expect(plugin.source.url).toMatch(/^https:\/\/github\.com\/agent-sh\/.+\.git$/);
+    expect(plugin.source.commit).toMatch(/^[0-9a-f]{40}$/);
+    if (plugin.source.ref) {
+      expect(plugin.source.ref).toBe(`v${plugin.version}`);
+    }
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentsys",
-  "version": "5.13.1",
+  "version": "5.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentsys",
-      "version": "5.13.1",
+      "version": "5.13.2",
       "license": "MIT",
       "workspaces": [
         "lib"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "version": "5.13.1",
+  "version": "5.13.2",
   "description": "A modular runtime and orchestration system for AI agents - works with Claude Code, OpenCode, and Codex CLI",
   "main": "lib/platform/detect-platform.js",
   "type": "commonjs",

--- a/site/content.json
+++ b/site/content.json
@@ -5,7 +5,7 @@
     "url": "https://agent-sh.github.io/agentsys",
     "repo": "https://github.com/agent-sh/agentsys",
     "npm": "https://www.npmjs.com/package/agentsys",
-    "version": "5.13.1",
+    "version": "5.13.2",
     "author": "Avi Fenesh",
     "author_url": "https://github.com/avifenesh"
   },


### PR DESCRIPTION
## Summary
- update the AgentSys marketplace pin to banthis v0.3.1
- add standalone plugin marketplace contract tests for banthis, skill-curator, and system-prompt-curator
- bump AgentSys to v5.13.2

## Validation
- npm test -- __tests__/marketplace-standalone-contract.test.js __tests__/pin-marketplace.test.js
- node scripts/pin-marketplace.js --dry-run
- npm run gen-docs:check
- npm run validate
- agnix --strict .
- npm test
- npm run preflight:release