### PR TITLE
Release agentsys v5.13.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "agentsys",
   "description": "24 specialized plugins for AI workflow automation - task orchestration, PR workflow, slop detection, code review, drift detection, enhancement analysis, documentation sync, unified static analysis, durable memory, negative behavior memory, skill and system prompt curation, perf investigations, topic research, agent config linting, cross-tool AI consultation, structured AI debate, workflow pattern learning, codebase onboarding, contributor guidance, and Zig language support",
-  "version": "5.13.2",
+  "version": "5.13.3",
   "owner": {
     "name": "Avi Fenesh",
     "url": "https://github.com/avifenesh"
@@ -127,11 +127,11 @@
       "source": {
         "source": "url",
         "url": "https://github.com/agent-sh/skill-curator.git",
-        "ref": "v1.0.0",
-        "commit": "e30ebfe3e7a5307e97fa4e6d59f538b12f8074c5"
+        "ref": "v1.0.1",
+        "commit": "4cca0b7c161710e3fb4f2d0aec477fc7b1e7cc88"
       },
       "description": "Canonical guidance for writing, reviewing, and maintaining production-grade SKILL.md files across agent tools",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "development",
       "homepage": "https://github.com/agent-sh/skill-curator"
     },
@@ -140,11 +140,11 @@
       "source": {
         "source": "url",
         "url": "https://github.com/agent-sh/system-prompt-curator.git",
-        "ref": "v2.0.0",
-        "commit": "277bee4b8b3b796d2a627132c88fb132479cbde0"
+        "ref": "v2.0.1",
+        "commit": "1ccf70fef983384a1d025c5882135abe16c32d1f"
       },
       "description": "Production-grade system prompt curation for autonomous coding agents and multi-agent orchestration",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "category": "development",
       "homepage": "https://github.com/agent-sh/system-prompt-curator"
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "version": "5.13.2",
+  "version": "5.13.3",
   "description": "Professional-grade slash commands for Claude Code with cross-platform support",
   "keywords": [
     "workflow",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.13.3] - 2026-05-17
+
+### Fixed
+- Updated the enhance skill analyzer to accept string-parsed `disable-model-invocation: true` metadata.
+
+### Changed
+- Updated `skill-curator` to `v1.0.1` and `system-prompt-curator` to `v2.0.1` so AgentSys consumes the hardened releases.
+
 ## [5.13.2] - 2026-05-17
 
 ### Changed

--- a/__tests__/enhance-hooks-skills-analyzer.test.js
+++ b/__tests__/enhance-hooks-skills-analyzer.test.js
@@ -50,6 +50,24 @@ describe('enhance hook/skill analyzers', () => {
     expect(result.triggerIssues[0].issue).toMatch(/trigger phrase/i);
   });
 
+  test('analyzeSkill accepts string true for disable-model-invocation', () => {
+    const skillDir = path.join(tempDir, 'skills', 'publisher');
+    fs.mkdirSync(skillDir, { recursive: true });
+    const filePath = path.join(skillDir, 'SKILL.md');
+    fs.writeFileSync(filePath, [
+      '---',
+      'name: publisher',
+      'description: Use when user asks to publish release notes.',
+      'disable-model-invocation: true',
+      '---',
+      '',
+      'Publish the release notes when explicitly invoked.'
+    ].join('\n'));
+
+    const result = analyzeSkill(filePath);
+    expect(result.structureIssues.some(issue => issue.patternId === 'side_effect_without_disable')).toBe(false);
+  });
+
   test('analyzeAllSkills finds nested SKILL.md files', () => {
     const skillA = path.join(tempDir, 'skills', 'alpha');
     const skillB = path.join(tempDir, 'plugins', 'beta', 'skills', 'beta-skill');

--- a/__tests__/marketplace-standalone-contract.test.js
+++ b/__tests__/marketplace-standalone-contract.test.js
@@ -11,16 +11,16 @@ const repoRoot = path.join(__dirname, '..');
 
 const expectedStandalonePlugins = {
   'skill-curator': {
-    version: '1.0.0',
-    ref: 'v1.0.0',
-    commit: 'e30ebfe3e7a5307e97fa4e6d59f538b12f8074c5',
+    version: '1.0.1',
+    ref: 'v1.0.1',
+    commit: '4cca0b7c161710e3fb4f2d0aec477fc7b1e7cc88',
     command: '/skill-curator',
     category: 'development',
   },
   'system-prompt-curator': {
-    version: '2.0.0',
-    ref: 'v2.0.0',
-    commit: '277bee4b8b3b796d2a627132c88fb132479cbde0',
+    version: '2.0.1',
+    ref: 'v2.0.1',
+    commit: '1ccf70fef983384a1d025c5882135abe16c32d1f',
     command: '/system-prompt-curator',
     category: 'development',
   },

--- a/lib/enhance/skill-patterns.js
+++ b/lib/enhance/skill-patterns.js
@@ -76,7 +76,11 @@ const skillPatterns = {
                (content && p.test(content));
       });
 
-      if (hasSideEffects && frontmatter['disable-model-invocation'] !== true) {
+      const disableModelInvocation = frontmatter['disable-model-invocation'];
+      const isManualOnly = disableModelInvocation === true ||
+        (typeof disableModelInvocation === 'string' && disableModelInvocation.toLowerCase() === 'true');
+
+      if (hasSideEffects && !isManualOnly) {
         return {
           issue: 'Skill with side effects should have disable-model-invocation: true',
           fix: 'Add "disable-model-invocation: true" to frontmatter for manual-only invocation'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentsys",
-  "version": "5.13.2",
+  "version": "5.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentsys",
-      "version": "5.13.2",
+      "version": "5.13.3",
       "license": "MIT",
       "workspaces": [
         "lib"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "version": "5.13.2",
+  "version": "5.13.3",
   "description": "A modular runtime and orchestration system for AI agents - works with Claude Code, OpenCode, and Codex CLI",
   "main": "lib/platform/detect-platform.js",
   "type": "commonjs",

--- a/site/content.json
+++ b/site/content.json
@@ -5,7 +5,7 @@
     "url": "https://agent-sh.github.io/agentsys",
     "repo": "https://github.com/agent-sh/agentsys",
     "npm": "https://www.npmjs.com/package/agentsys",
-    "version": "5.13.2",
+    "version": "5.13.3",
     "author": "Avi Fenesh",
     "author_url": "https://github.com/avifenesh"
   },


### PR DESCRIPTION
## Summary
- fix enhance skill analyzer handling for string-parsed disable-model-invocation metadata
- update skill-curator to v1.0.1 and system-prompt-curator to v2.0.1
- keep standalone marketplace contract tests pinned to immutable release commits

## Validation
- npm test
- npm run validate
- npm run gen-docs:check
- npm run expand-templates:check
- npm run gen-adapters:check
- agnix --strict .
- node scripts/pin-marketplace.js --dry-run
- npm run preflight:release
- npm pack --dry-run