### PR TITLE
Fix package-lock version drift (5.13.4 -> 5.13.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentsys",
-  "version": "5.13.4",
+  "version": "5.13.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentsys",
-      "version": "5.13.4",
+      "version": "5.13.5",
       "license": "MIT",
       "workspaces": [
         "lib"


### PR DESCRIPTION
`scripts/validate-repo-consistency.js` fails: `package-lock.json version 5.13.4 does not match package.json 5.13.5`.

Release commit b3ee2a5 bumped `package.json` to 5.13.5 but the lockfile stayed at 5.13.4. This syncs the lock `version` (root + `packages[""]`) to 5.13.5.

After: `node scripts/validate-repo-consistency.js` -> `[OK] Repository consistency checks passed`.