### PR TITLE
Bump mojo marketplace pin to v0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -331,11 +331,11 @@
       "source": {
         "source": "url",
         "url": "https://github.com/agent-sh/mojo.git",
-        "ref": "v0.1.1",
-        "commit": "95143ab532bd9b8ede8aaf465bf87948835dc78a"
+        "ref": "v0.2.0",
+        "commit": "4d6f5fe71e03380f8532a0a8419903f4f548a587"
       },
       "description": "Teach agents to write idiomatic, correct, performant, current Mojo (v1.0.0b1) - fundamentals, performance (SIMD/vectorize/parallelize), and GPU kernels; prevents stale pre-2025 syntax",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "category": "development",
       "homepage": "https://github.com/agent-sh/mojo"
     }


### PR DESCRIPTION
mojo `v0.2.0` was published: https://github.com/agent-sh/mojo/releases/tag/v0.2.0

Updates the immutable pin so marketplace users get the new version:
- `ref`: `v0.1.1` -> `v0.2.0`
- `commit`: `95143ab` -> `4d6f5fe71e03380f8532a0a8419903f4f548a587`
- `version`: `0.1.1` -> `0.2.0`

### What's in mojo v0.2.0
- Fixed 3 stale syntax rules (std. import prefix, comptime if/for, keyword-only lifecycle ctors) + dead reference URL
- Added SOTA blind-spots layer (memory/CPU/GPU/Python interop) + iterator protocol shape

### Scope
Single-entry edit. `scripts/pin-marketplace.js` resolves the same SHA (verified via `--dry-run`) but rewrites all 25 entries; kept this surgical to avoid re-pinning unrelated plugins. SHA matches the dry-run output. `npx jest marketplace-standalone-contract` passes (4/4).