### PR TITLE
Represent mojo skill in docs + refresh v0.2.0 description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -334,7 +334,7 @@
         "ref": "v0.2.0",
         "commit": "4d6f5fe71e03380f8532a0a8419903f4f548a587"
       },
-      "description": "Teach agents to write idiomatic, correct, performant, current Mojo (v1.0.0b1) - fundamentals, performance (SIMD/vectorize/parallelize), and GPU kernels; prevents stale pre-2025 syntax",
+      "description": "Teach agents to write idiomatic, correct, performant, current Mojo (v1.0.0b1) - syntax, ownership and CPU/memory optimization (copies, SIMD, vectorize/parallelize), GPU kernels (DeviceContext/LayoutTensor), and Mojo/Python interop; prevents stale pre-2025 syntax",
       "version": "0.2.0",
       "category": "development",
       "homepage": "https://github.com/agent-sh/mojo"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@
 <!-- GEN:START:claude-architecture -->
 ```
 lib/          → Shared library (vendored to plugins)
-plugins/      → 25 plugins, 50 agents (40 file-based + 10 role-based), 45 skills
+plugins/      → 25 plugins, 50 agents (40 file-based + 10 role-based), 46 skills
 adapters/     → Platform adapters (opencode-plugin/, opencode/, codex/)
 checklists/   → Action checklists (9 files)
 bin/cli.js    → npm CLI installer
@@ -108,7 +108,7 @@ bin/cli.js    → npm CLI installer
 | onboard | 1 | 1 | Codebase onboarding |
 | can-i-help | 1 | 1 | Contributor guidance |
 | zig-lsp | 0 | 0 |  |
-| mojo | 0 | 0 |  |
+| mojo | 0 | 1 |  |
 <!-- GEN:END:claude-architecture -->
 
 **Pattern**: `Command → Agent → Skill` (orchestration → invocation → implementation)

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Each command works standalone. Together, they compose into end-to-end pipelines.
 | Category | Skills | Plugin |
 |----------|--------|--------|
 | **Message Queues** | `glide-mq`, `glide-mq-migrate-bullmq`, `glide-mq-migrate-bee` | [agent-sh/glidemq](https://github.com/agent-sh/glidemq) |
+| **Languages** | `mojo` | [agent-sh/mojo](https://github.com/agent-sh/mojo) |
 
 Skills are the reusable implementation units. Agents invoke skills; commands orchestrate agents. When you install a plugin, its skills become available to all agents in that session.
 

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -69,7 +69,8 @@ const CATEGORY_MAP = {
   'onboard': 'Onboarding',
   'can-i-help': 'Onboarding',
   'audit-project': 'Code Review',
-  'glidemq': 'Message Queues'
+  'glidemq': 'Message Queues',
+  'mojo': 'Languages'
 };
 
 // Static skill definitions for cross-repo plugins (not discoverable locally)
@@ -115,6 +116,7 @@ const STATIC_SKILLS = [
   { plugin: 'onboard', name: 'onboard' },
   { plugin: 'can-i-help', name: 'can-i-help' },
   { plugin: 'audit-project', name: 'audit-project' },
+  { plugin: 'mojo', name: 'mojo' },
   { plugin: 'glidemq', name: 'glide-mq' },
   { plugin: 'glidemq', name: 'glide-mq-migrate-bullmq' },
   { plugin: 'glidemq', name: 'glide-mq-migrate-bee' },
@@ -284,7 +286,7 @@ function generateSkillsTable(skills) {
   const categoryOrder = [
     'Workflow', 'Message Queues', 'Enhancement', 'Performance', 'Cleanup',
     'Code Review', 'AI Collaboration', 'Onboarding',
-    'Web', 'Release', 'Analysis', 'Memory', 'Linting', 'Other'
+    'Web', 'Release', 'Analysis', 'Memory', 'Linting', 'Languages', 'Other'
   ];
 
   const lines = [

--- a/site/content.json
+++ b/site/content.json
@@ -33,7 +33,7 @@
       "suffix": ""
     },
     {
-      "value": "45",
+      "value": "46",
       "label": "Skills",
       "suffix": ""
     },


### PR DESCRIPTION
Follow-up to the mojo v0.2.0 pin bump (#360): mojo was registered but not actually represented in generated docs.

### Problems
- `STATIC_SKILLS` omitted mojo's skill -> architecture table counted mojo as 0 skills; AGENTS.md total said 45 while README said 46.
- `CATEGORY_MAP` had no mojo entry and the skills-table `categoryOrder` omitted `Languages`, so the group never rendered (count included it, row dropped - caught by the generate-docs 'all skills are represented' test once mojo was added).
- Marketplace description was stale vs v0.2.0 (no mention of memory optimization or Python interop).

### Fixes
- Add mojo to `STATIC_SKILLS`, map to new `Languages` category, add `Languages` to `categoryOrder`.
- Regenerate AGENTS.md + site/content.json (mojo 0->1, total 45->46, consistent with README).
- List mojo in README's hand-maintained External skill plugins table.
- Refresh marketplace mojo description for v0.2.0 content.

### Scope / tests
Pin unchanged (v0.2.0 / 4d6f5fe). 190 marketplace/generate-docs/readme tests pass; `generate-docs --check` fresh. Did not touch zig representation (separate pre-existing gap).