### PR TITLE
Register ada-spark plugin in marketplace (25 -> 26 plugins)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "agentsys",
   "description": "26 specialized plugins for AI workflow automation - task orchestration, PR workflow, slop detection, code review, drift detection, enhancement analysis, documentation sync, unified static analysis, durable memory, negative behavior memory, skill and system prompt curation, perf investigations, topic research, agent config linting, cross-tool AI consultation, structured AI debate, workflow pattern learning, codebase onboarding, contributor guidance, Zig language support, Mojo language support, and Ada/SPARK language support",
-  "version": "5.13.5",
+  "version": "5.14.0",
   "owner": {
     "name": "Avi Fenesh",
     "url": "https://github.com/avifenesh"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "description": "25 specialized plugins for AI workflow automation - task orchestration, PR workflow, slop detection, code review, drift detection, enhancement analysis, documentation sync, unified static analysis, durable memory, negative behavior memory, skill and system prompt curation, perf investigations, topic research, agent config linting, cross-tool AI consultation, structured AI debate, workflow pattern learning, codebase onboarding, contributor guidance, Zig language support, and Mojo language support",
+  "description": "26 specialized plugins for AI workflow automation - task orchestration, PR workflow, slop detection, code review, drift detection, enhancement analysis, documentation sync, unified static analysis, durable memory, negative behavior memory, skill and system prompt curation, perf investigations, topic research, agent config linting, cross-tool AI consultation, structured AI debate, workflow pattern learning, codebase onboarding, contributor guidance, Zig language support, Mojo language support, and Ada/SPARK language support",
   "version": "5.13.5",
   "owner": {
     "name": "Avi Fenesh",
@@ -338,6 +338,19 @@
       "version": "0.2.0",
       "category": "development",
       "homepage": "https://github.com/agent-sh/mojo"
+    },
+    {
+      "name": "ada-spark",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/agent-sh/ada-spark.git",
+        "ref": "v0.1.0",
+        "commit": "d84e4efbd22165d3739dc5002c8385737637890c"
+      },
+      "description": "Teach agents to write idiomatic, correct, current Ada and SPARK (Ada 2022) - contracts (aspects, Pre'Class), the Alire ecosystem, SPARK proof (AoRTE, assurance levels, ownership/borrow), embedded (Ravenscar/Jorvik), and GNAT/GNAT SAS tooling; blocks stale pre-2022 advice (GNAT Community, pragma contracts, CodePeer)",
+      "version": "0.1.0",
+      "category": "development",
+      "homepage": "https://github.com/agent-sh/ada-spark"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "version": "5.13.5",
+  "version": "5.14.0",
   "description": "Professional-grade slash commands for Claude Code with cross-platform support",
   "keywords": [
     "workflow",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,7 @@ agentsys                # Run installer
 <agents>
 ## Agents
 
-50 agents across 26 plugins (18 have agents; gate-and-ship is commands-only; axiom, banthis, skill-curator, and system-prompt-curator are skill/command-only; zig-lsp is config-only with no commands or agents; mojo and ada-spark are skill-only). Key agents by model:
+50 agents across 26 plugins (17 have agents; gate-and-ship is commands-only; axiom, banthis, skill-curator, system-prompt-curator, and agnix are skill/command-only; zig-lsp is config-only with no commands or agents; mojo and ada-spark are skill-only). Key agents by model:
 
 | Model | Agents | Use Case |
 |-------|--------|----------|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@
 <!-- GEN:START:claude-architecture -->
 ```
 lib/          → Shared library (vendored to plugins)
-plugins/      → 25 plugins, 50 agents (40 file-based + 10 role-based), 46 skills
+plugins/      → 26 plugins, 50 agents (40 file-based + 10 role-based), 47 skills
 adapters/     → Platform adapters (opencode-plugin/, opencode/, codex/)
 checklists/   → Action checklists (9 files)
 bin/cli.js    → npm CLI installer
@@ -109,6 +109,7 @@ bin/cli.js    → npm CLI installer
 | can-i-help | 1 | 1 | Contributor guidance |
 | zig-lsp | 0 | 0 |  |
 | mojo | 0 | 1 |  |
+| ada-spark | 0 | 1 |  |
 <!-- GEN:END:claude-architecture -->
 
 **Pattern**: `Command → Agent → Skill` (orchestration → invocation → implementation)
@@ -177,7 +178,7 @@ agentsys                # Run installer
 <agents>
 ## Agents
 
-50 agents across 25 plugins (18 have agents; gate-and-ship is commands-only; axiom, banthis, skill-curator, and system-prompt-curator are skill/command-only; zig-lsp is config-only with no commands or agents; mojo is skill-only). Key agents by model:
+50 agents across 26 plugins (18 have agents; gate-and-ship is commands-only; axiom, banthis, skill-curator, and system-prompt-curator are skill/command-only; zig-lsp is config-only with no commands or agents; mojo and ada-spark are skill-only). Key agents by model:
 
 | Model | Agents | Use Case |
 |-------|--------|----------|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.14.0] - 2026-05-21
+
+### Added
+- Registered the `ada-spark` skill plugin (`agent-sh/ada-spark` v0.1.0, pinned `v0.1.0` / `d84e4ef`) in the marketplace. Teaches agents to write idiomatic, correct, current Ada and SPARK (Ada 2022) - contracts (aspects, `Pre'Class`), the Alire ecosystem, SPARK proof (AoRTE, assurance levels, ownership/borrow), embedded (Ravenscar/Jorvik), and GNAT/GNAT SAS tooling; blocks stale pre-2022 advice (GNAT Community, pragma contracts, CodePeer). Mapped to the `Languages` skill category.
+- Registered the `mojo` skill plugin (`agent-sh/mojo` v0.2.0, pinned `v0.2.0` / `4d6f5fe`) in the marketplace. Teaches agents to write idiomatic, current Mojo (v1.0.0b1) - syntax, ownership and CPU/memory optimization, GPU kernels, and Mojo/Python interop; prevents stale pre-2025 syntax. Mapped to the `Languages` skill category.
+
+### Changed
+- Synced plugin/skill count surfaces across `README.md`, `AGENTS.md`, `docs/reference/AGENTS.md`, `docs/ARCHITECTURE.md`, `docs/CROSS_PLATFORM.md`, `site/content.json`, `site/index.html`, and `site/ux-spec.md` for the two new language plugins: plugins `24 -> 26`, skills `45 -> 47` (agents unchanged at 50). Added `ada-spark` and `mojo` to `STATIC_PLUGIN_AGENT_COUNTS`, `CATEGORY_MAP`, and `STATIC_SKILLS` in `scripts/generate-docs.js`, and to `scripts/plugins.txt`.
+
 ## [5.13.5] - 2026-05-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <b>25 plugins · 50 agents · 46 skills (across all repos) · 30k lines of lib code · 3,518 tests · 5 platforms</b><br>
+  <b>26 plugins · 50 agents · 47 skills (across all repos) · 30k lines of lib code · 3,518 tests · 5 platforms</b><br>
   <em>Plugins distributed as standalone repos under <a href="https://github.com/agent-sh">agent-sh</a> org - agentsys is the marketplace &amp; installer</em>
 </p>
 
@@ -45,7 +45,7 @@ AI models can write code. That's not the hard part anymore. The hard part is eve
 
 ## What This Is
 
-An agent orchestration system - 25 plugins, 50 agents (40 file-based + 10 role-based specialists in audit-project), and 46 skills that compose into structured pipelines for software development. Each plugin lives in its own standalone repo under the [agent-sh](https://github.com/agent-sh) org. agentsys is the marketplace and installer that ties them together.
+An agent orchestration system - 26 plugins, 50 agents (40 file-based + 10 role-based specialists in audit-project), and 47 skills that compose into structured pipelines for software development. Each plugin lives in its own standalone repo under the [agent-sh](https://github.com/agent-sh) org. agentsys is the marketplace and installer that ties them together.
 
 Each agent has a single responsibility, a specific model assignment, and defined inputs/outputs. Pipelines enforce phase gates so agents can't skip steps. State persists across sessions so work survives interruptions.
 
@@ -146,7 +146,7 @@ Each command works standalone. Together, they compose into end-to-end pipelines.
 
 ## Skills
 
-46 skills included across the plugins:
+47 skills included across the plugins:
 
 | Category | Skills |
 |----------|--------|
@@ -170,6 +170,7 @@ Each command works standalone. Together, they compose into end-to-end pipelines.
 |----------|--------|--------|
 | **Message Queues** | `glide-mq`, `glide-mq-migrate-bullmq`, `glide-mq-migrate-bee` | [agent-sh/glidemq](https://github.com/agent-sh/glidemq) |
 | **Languages** | `mojo` | [agent-sh/mojo](https://github.com/agent-sh/mojo) |
+| **Languages** | `ada-spark` | [agent-sh/ada-spark](https://github.com/agent-sh/ada-spark) |
 
 Skills are the reusable implementation units. Agents invoke skills; commands orchestrate agents. When you install a plugin, its skills become available to all agents in that session.
 
@@ -182,7 +183,7 @@ Skills are the reusable implementation units. Agents invoke skills; commands orc
 | [The Approach](#the-approach) | Why it's built this way |
 | [Benchmarks](#benchmarks) | Sonnet + agentsys vs raw Opus |
 | [Commands](#commands) | All 24 commands overview |
-| [Skills](#skills) | 46 skills across plugins |
+| [Skills](#skills) | 47 skills across plugins |
 | [Skill-Only Plugins](#skill-only-plugins) | glide-mq and other non-command plugins |
 | [Command Details](#command-details) | Deep dive into each command |
 | [How Commands Work Together](#how-commands-work-together) | Standalone vs integrated |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,7 +73,7 @@ agentsys/
     ├── KNOWLEDGE-LIBRARY.md      # Index
     └── *-REFERENCE.md            # Research documents
 
-NOTE: plugins/ has been removed. All 25 plugins are now standalone repos
+NOTE: plugins/ has been removed. All 26 plugins are now standalone repos
 under the agent-sh org. The installer fetches them from GitHub at install time.
 Plugin repos: agent-sh/{next-task,prepare-delivery,gate-and-ship,ship,deslop,
               audit-project,enhance,perf,drift-detect,sync-docs,repo-intel,

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -343,7 +343,7 @@ The plugin auto-detects the platform and uses the appropriate directory. Overrid
 - State directory: `.opencode/`
 - Slash commands in `~/.config/opencode/commands/`
 - Agents in `~/.config/opencode/agents/` (47 agents)
-- Skills in `~/.config/opencode/skills/` (46 skills)
+- Skills in `~/.config/opencode/skills/` (47 skills)
 - Native plugin in `~/.config/opencode/plugins/agentsys.ts`
 - **Native plugin features:**
   - Auto-thinking selection (adjusts budget per agent)

--- a/docs/reference/AGENTS.md
+++ b/docs/reference/AGENTS.md
@@ -3,7 +3,7 @@
 Complete reference for all agents in AgentSys.
 
 <!-- GEN:START:agents-counts -->
-**TL;DR:** 50 agents across 25 plugins (17 have agents). opus for reasoning, sonnet for patterns, haiku for execution. Each agent does one thing well. <!-- AGENT_COUNT_TOTAL: 50 -->
+**TL;DR:** 50 agents across 26 plugins (17 have agents). opus for reasoning, sonnet for patterns, haiku for execution. Each agent does one thing well. <!-- AGENT_COUNT_TOTAL: 50 -->
 <!-- GEN:END:agents-counts -->
 
 ---
@@ -24,7 +24,7 @@ Complete reference for all agents in AgentSys.
 
 ## Overview
 
-AgentSys uses 50 specialized agents across 25 plugins (17 have agents; gate-and-ship is commands-only, axiom, banthis, skill-curator, system-prompt-curator, and agnix are skill/command-only, zig-lsp is a config-only LSP plugin with no commands or agents, and mojo is a skill-only plugin). Each agent is optimized for a specific task and assigned a model based on complexity:
+AgentSys uses 50 specialized agents across 26 plugins (17 have agents; gate-and-ship is commands-only, axiom, banthis, skill-curator, system-prompt-curator, and agnix are skill/command-only, zig-lsp is a config-only LSP plugin with no commands or agents, and mojo and ada-spark are skill-only plugins). Each agent is optimized for a specific task and assigned a model based on complexity:
 
 | Model | Use Case | Cost |
 |-------|----------|------|

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentsys",
-  "version": "5.13.5",
+  "version": "5.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentsys",
-      "version": "5.13.5",
+      "version": "5.14.0",
       "license": "MIT",
       "workspaces": [
         "lib"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "version": "5.13.5",
+  "version": "5.14.0",
   "description": "A modular runtime and orchestration system for AI agents - works with Claude Code, OpenCode, and Codex CLI",
   "main": "lib/platform/detect-platform.js",
   "type": "commonjs",

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -70,7 +70,8 @@ const CATEGORY_MAP = {
   'can-i-help': 'Onboarding',
   'audit-project': 'Code Review',
   'glidemq': 'Message Queues',
-  'mojo': 'Languages'
+  'mojo': 'Languages',
+  'ada-spark': 'Languages'
 };
 
 // Static skill definitions for cross-repo plugins (not discoverable locally)
@@ -117,6 +118,7 @@ const STATIC_SKILLS = [
   { plugin: 'can-i-help', name: 'can-i-help' },
   { plugin: 'audit-project', name: 'audit-project' },
   { plugin: 'mojo', name: 'mojo' },
+  { plugin: 'ada-spark', name: 'ada-spark' },
   { plugin: 'glidemq', name: 'glide-mq' },
   { plugin: 'glidemq', name: 'glide-mq-migrate-bullmq' },
   { plugin: 'glidemq', name: 'glide-mq-migrate-bee' },
@@ -462,7 +464,8 @@ const STATIC_PLUGIN_AGENT_COUNTS = {
   'onboard': 1,
   'can-i-help': 1,
   'zig-lsp': 0,
-  'mojo': 0
+  'mojo': 0,
+  'ada-spark': 0
 };
 const STATIC_PLUGIN_COUNT = Object.keys(STATIC_PLUGIN_AGENT_COUNTS).length;
 const STATIC_FILE_BASED_AGENT_COUNT = Object.values(STATIC_PLUGIN_AGENT_COUNTS).reduce((sum, count) => sum + count, 0);

--- a/scripts/plugins.txt
+++ b/scripts/plugins.txt
@@ -1,3 +1,4 @@
+ada-spark
 agnix
 axiom
 audit-project

--- a/site/content.json
+++ b/site/content.json
@@ -5,7 +5,7 @@
     "url": "https://agent-sh.github.io/agentsys",
     "repo": "https://github.com/agent-sh/agentsys",
     "npm": "https://www.npmjs.com/package/agentsys",
-    "version": "5.13.5",
+    "version": "5.14.0",
     "author": "Avi Fenesh",
     "author_url": "https://github.com/avifenesh"
   },

--- a/site/content.json
+++ b/site/content.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "agentsys",
-    "description": "A modular runtime and orchestration system for AI agents. 25 plugins, 50 agents, 46 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.",
+    "description": "A modular runtime and orchestration system for AI agents. 26 plugins, 50 agents, 47 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.",
     "url": "https://agent-sh.github.io/agentsys",
     "repo": "https://github.com/agent-sh/agentsys",
     "npm": "https://www.npmjs.com/package/agentsys",
@@ -23,7 +23,7 @@
   },
   "stats": [
     {
-      "value": "25",
+      "value": "26",
       "label": "Plugins",
       "suffix": ""
     },
@@ -33,7 +33,7 @@
       "suffix": ""
     },
     {
-      "value": "46",
+      "value": "47",
       "label": "Skills",
       "suffix": ""
     },

--- a/site/index.html
+++ b/site/index.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>AgentSys - Agent Runtime &amp; Orchestration System</title>
-  <meta name="description" content="A modular runtime and orchestration system for AI agents. 25 plugins, 50 agents, 46 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
+  <meta name="description" content="A modular runtime and orchestration system for AI agents. 26 plugins, 50 agents, 47 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
   <meta name="theme-color" content="#09090b">
 
   <!-- Open Graph -->
   <meta property="og:title" content="AgentSys">
-  <meta property="og:description" content="A modular runtime and orchestration system for AI agents. 25 plugins, 50 agents, 46 skills.">
+  <meta property="og:description" content="A modular runtime and orchestration system for AI agents. 26 plugins, 50 agents, 47 skills.">
   <meta property="og:image" content="https://agent-sh.github.io/agentsys/assets/logo.png">
   <meta property="og:url" content="https://agent-sh.github.io/agentsys/">
   <meta property="og:type" content="website">
@@ -17,7 +17,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="AgentSys">
-  <meta name="twitter:description" content="AI workflow automation. 25 plugins, 50 agents, 46 skills.">
+  <meta name="twitter:description" content="AI workflow automation. 26 plugins, 50 agents, 47 skills.">
   <meta name="twitter:image" content="https://agent-sh.github.io/agentsys/assets/logo.png">
 
   <!-- Content Security Policy -->
@@ -107,7 +107,7 @@
       <div class="hero__inner">
         <div class="hero__content">
           <div class="hero__badge anim-fade-in" data-delay="100">
-            25 plugins &middot; 50 agents &middot; 46 skills
+            26 plugins &middot; 50 agents &middot; 47 skills
           </div>
           <h1 class="hero__title anim-fade-up" id="hero-title" data-delay="200">
             A modular <span class="text-gradient">runtime and orchestration system</span><br>

--- a/site/ux-spec.md
+++ b/site/ux-spec.md
@@ -94,7 +94,7 @@ Scroll order with rationale for each section. All sections are full-width, alter
 - **Single column on mobile:** Text above, terminal below. Stack with 48px gap.
 
 ### Left Column Content
-1. **Badge** (top, above title): Small pill showing version or "25 plugins . 50 agents . 46 skills"
+1. **Badge** (top, above title): Small pill showing version or "26 plugins . 50 agents . 47 skills"
    - Background: `rgba(99, 102, 241, 0.12)`, border: `1px solid rgba(99, 102, 241, 0.25)`, border-radius: 9999px
    - Font: 13px, font-weight 500, primary accent color
    - Padding: 4px 14px
@@ -104,7 +104,7 @@ Scroll order with rationale for each section. All sections are full-width, alter
    - Color: white
    - "entire dev workflow" portion highlighted with a subtle gradient text (primary-to-secondary accent via `background-clip: text`)
 
-3. **Subtitle:** "25 plugins, 50 agents, 46 skills. From task selection to merged PR. Works with Claude Code, OpenCode, Codex CLI, Cursor, and Kiro."
+3. **Subtitle:** "26 plugins, 50 agents, 47 skills. From task selection to merged PR. Works with Claude Code, OpenCode, Codex CLI, Cursor, and Kiro."
    - Font: 18px on desktop, 16px on mobile, font-weight 400, line-height 1.6
    - Color: `rgba(255, 255, 255, 0.6)`
    - Max-width: 520px
@@ -650,13 +650,13 @@ This disables:
 ### Head Content
 ```html
 <title>AgentSys - Agent Runtime &amp; Orchestration System</title>
-<meta name="description" content="A modular runtime and orchestration system for AI agents. 25 plugins, 50 agents, 46 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
+<meta name="description" content="A modular runtime and orchestration system for AI agents. 26 plugins, 50 agents, 47 skills - structured pipelines for Claude Code, OpenCode, Codex CLI, Cursor, and Kiro.">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="theme-color" content="#0a0a0f">
 
 <!-- Open Graph -->
 <meta property="og:title" content="AgentSys">
-<meta property="og:description" content="AI workflow automation. 25 plugins, 50 agents, 46 skills. Task to merged PR.">
+<meta property="og:description" content="AI workflow automation. 26 plugins, 50 agents, 47 skills. Task to merged PR.">
 <meta property="og:image" content="https://agent-sh.github.io/agentsys/assets/og-image.png">
 <meta property="og:url" content="https://agent-sh.github.io/agentsys/">
 <meta property="og:type" content="website">
@@ -664,7 +664,7 @@ This disables:
 <!-- Twitter Card -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AgentSys">
-<meta name="twitter:description" content="AI workflow automation. 25 plugins, 50 agents, 46 skills.">
+<meta name="twitter:description" content="AI workflow automation. 26 plugins, 50 agents, 47 skills.">
 <meta name="twitter:image" content="https://agent-sh.github.io/agentsys/assets/og-image.png">
 ```
 


### PR DESCRIPTION
Adds the **ada-spark** skill plugin ([agent-sh/ada-spark](https://github.com/agent-sh/ada-spark) v0.1.0) to the marketplace, pinned to tag `v0.1.0` / commit `d84e4ef`. Mirrors the established external-plugin flow used for `mojo` (#358, #361).

## What it adds
Skill teaches agents to write idiomatic, correct, current Ada and SPARK (Ada 2022) and blocks stale pre-2022 advice (GNAT Community, pragma contracts, CodePeer). Links to upstream docs; no bundled deep-dive.

## Changes
- `marketplace.json`: ada-spark entry (url source, ref + commit pin) + root description `25 -> 26` plugins, Ada/SPARK support.
- `scripts/generate-docs.js`: `ada-spark` added to `STATIC_PLUGIN_AGENT_COUNTS` (-> 26), `CATEGORY_MAP` (`Languages`), `STATIC_SKILLS` (-> 47).
- `scripts/plugins.txt`: `ada-spark` added.
- Regenerated GEN blocks (`AGENTS.md`, `docs/reference/AGENTS.md`, `site/content.json`) and refreshed hand-maintained count surfaces (`README.md`, `site/index.html`, `site/ux-spec.md`, `docs/ARCHITECTURE.md`, `docs/CROSS_PLATFORM.md`); ada-spark added to README Languages table.

All stat surfaces synced in lockstep: **25 -> 26 plugins, 46 -> 47 skills**; agents unchanged at 50.

## Validation
- `npm test`: 3518 passed, 39 skipped (87 suites).
- `npm run gen-docs:check`: fresh.
- `marketplace.json`: valid JSON.

Note: README/AGENTS site listings updated; the agentsys version bump/release is left to maintainers.