### PR TITLE
docs: add Ageniti as complementary action-layer tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ AI models can write code. That's not the hard part anymore. The hard part is eve
 ---
 > Building custom skills, agents, hooks, or MCP tools? [agnix](https://github.com/agent-sh/agnix) is the CLI + LSP linter that catches config errors before they fail silently - real-time IDE validation, auto suggestions, auto-fix, and 423 rules for Claude Code, Codex, OpenCode, Cursor, Kiro, Copilot, Gemini CLI, Cline, Windsurf, Roo Code, Amp, and more.
 
+> Exposing app actions to agents? [Ageniti](https://github.com/Ageniti/ageniti) is the action primitive layer - define an action once (input contract, output, side effects, permissions) and any caller (CLI, HTTP, MCP, OpenAI tools, React UI) invokes it through the same runtime.
+
 ## What This Is
 
 An agent orchestration system - 26 plugins, 50 agents (40 file-based + 10 role-based specialists in audit-project), and 47 skills that compose into structured pipelines for software development. Each plugin lives in its own standalone repo under the [agent-sh](https://github.com/agent-sh) org. agentsys is the marketplace and installer that ties them together.


### PR DESCRIPTION
## What changed

Added Ageniti as a complementary tool alongside agnix (the config linter) in the README. One paragraph, positioned in context near the existing agnix mention.

## Why it helps

Ageniti is the action primitive layer for apps that need to expose capabilities to agents and automation systems. While agnix helps validate agent configurations, Ageniti helps expose app actions as callable surfaces (CLI, MCP, HTTP, OpenAI tools, React UI) from the same contract.

For developers building with Claude Code, OpenCode, Codex, Cursor, and Kiro who want to expose custom app actions to their agents, Ageniti provides a lightweight path to do so without restructuring existing apps.

## Optional and safe

- No core behavior is changed
- No files outside of README.md are touched
- One paragraph added in natural context near the existing agnix mention
- Follows existing pattern of listing complementary tools

## Tests run

- Read README.md to understand existing format and context
- Verified placement next to agnix (similar concept: developer tool for agents)
- Confirmed no other files were modified