### PR TITLE
test(repo-intel): drop stale aiRatio test (query removed)

### DIFF
--- a/__tests__/repo-intel-queries.test.js
+++ b/__tests__/repo-intel-queries.test.js
@@ -87,13 +87,6 @@ describe('lib/repo-intel/queries', () => {
       expect(args[args.indexOf('--min-changes') + 1]).toBe('3');
     });
 
-    test('aiRatio with pathFilter adds --path-filter', () => {
-      binary.runAnalyzer.mockReturnValue('{}');
-      queries.aiRatio(tempDir, { pathFilter: 'src/' });
-      const args = binary.runAnalyzer.mock.calls[0][0];
-      expect(args[args.indexOf('--path-filter') + 1]).toBe('src/');
-    });
-
     test('diffRisk joins files with comma', () => {
       binary.runAnalyzer.mockReturnValue('[]');
       queries.diffRisk(tempDir, ['a.js', 'b.js', 'c.js']);


### PR DESCRIPTION
queries.aiRatio was removed when agent-analyzer dropped AI attribution (v0.5.0). Stale test failed CI ('aiRatio is not a function'). Removed. 19/19 pass.