### PR TITLE
chore: release v6.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "agentsys",
   "description": "26 specialized plugins for AI workflow automation - task orchestration, PR workflow, slop detection, code review, drift detection, enhancement analysis, documentation sync, unified static analysis, durable memory, negative behavior memory, skill and system prompt curation, perf investigations, topic research, agent config linting, cross-tool AI consultation, structured AI debate, workflow pattern learning, codebase onboarding, contributor guidance, Zig language support, Mojo language support, and Ada/SPARK language support",
-  "version": "5.14.0",
+  "version": "6.0.0",
   "owner": {
     "name": "Avi Fenesh",
     "url": "https://github.com/avifenesh"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "version": "5.14.0",
+  "version": "6.0.0",
   "description": "Professional-grade slash commands for Claude Code with cross-platform support",
   "keywords": [
     "workflow",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0] - 2026-05-29
+
+### Removed
+- **BREAKING: Dropped the `axiom` and `web-ctl` plugins from the marketplace** (#365). Both repositories were retired; their marketplace entries, `plugins.txt` rows, `.kiro` mirrors (`web-auth`, `web-browse`, `web-session`), and all site/docs references were scrubbed. Installable plugin count is now 24 (was 26). Users who previously installed `axiom` or `web-ctl` from the marketplace must remove them; they will no longer resolve.
+
+### Added
+- **Unified `repo-intel` core library** synced from agent-core (#373). The vendored `lib/repo-intel/` now exposes a single surface that folds the former `repo-map` lifecycle and the embedder into one module: `init`/`update`/`status`/`load`/`loadRaw`/`exists`, typed `queries.*`, LLM-augmentation write-path (`applyDescriptors`/`applySummary`), and an opt-in `embed` submodule (orchestrator, preference, binary resolver) for semantic search and duplicate detection. `lib/repo-map` remains as a deprecated compatibility shim. `lib/index.js` now exports `repoIntel` alongside `repoMap`.
+
+### Fixed
+- `skill-patterns` `side_effect_without_disable` now accepts both the YAML boolean `true` and the quoted string `"true"` for `disable-model-invocation`, so a frontmatter value of `"true"` is no longer wrongly re-flagged.
+- Bounded 19 polynomial-ReDoS regexes and closed 2 prototype-pollution sinks across the synced `collectors`/`enhance` lib (match semantics preserved; verified by equivalence testing).
+- Removed the stale `aiRatio` query test - the analyzer dropped AI-authorship attribution and the query no longer exists (#372).
+
 ## [5.14.0] - 2026-05-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentsys",
-  "version": "5.14.0",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentsys",
-      "version": "5.14.0",
+      "version": "6.0.0",
       "license": "MIT",
       "workspaces": [
         "lib"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "version": "5.14.0",
+  "version": "6.0.0",
   "description": "A modular runtime and orchestration system for AI agents - works with Claude Code, OpenCode, and Codex CLI",
   "main": "lib/platform/detect-platform.js",
   "type": "commonjs",

--- a/site/content.json
+++ b/site/content.json
@@ -5,7 +5,7 @@
     "url": "https://agent-sh.github.io/agentsys",
     "repo": "https://github.com/agent-sh/agentsys",
     "npm": "https://www.npmjs.com/package/agentsys",
-    "version": "5.14.0",
+    "version": "6.0.0",
     "author": "Avi Fenesh",
     "author_url": "https://github.com/avifenesh"
   },


### PR DESCRIPTION
## v6.0.0 — major

### BREAKING
- Removed `axiom` + `web-ctl` plugins from the marketplace (26 → 24 installable). Both repos retired; entries, plugins.txt, .kiro mirrors, site/docs scrubbed. Prior installs of these no longer resolve.

### Added
- Unified `repo-intel` core lib synced from agent-core: folds former repo-map lifecycle + embedder into one surface (init/update/status/load/loadRaw, typed queries, applyDescriptors/applySummary, opt-in embed submodule). repo-map kept as deprecated shim; lib/index exports repoIntel.

### Fixed
- skill-patterns accepts string `"true"` for disable-model-invocation
- 19 polynomial-ReDoS + 2 prototype-pollution sinks hardened (semantics preserved)
- dropped stale aiRatio test

All release gates pass locally: test, validate-plugins, validate, templates, adapters. Versions consistent at 6.0.0 (package/plugin/marketplace/site/lock).