### PR TITLE
feat(marketplace): add orientation plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -325,6 +325,19 @@
       "version": "0.1.0",
       "category": "development",
       "homepage": "https://github.com/agent-sh/ada-spark"
+    },
+    {
+      "name": "orientation",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/agent-sh/orientation.git",
+        "ref": "v0.2.0",
+        "commit": "417d496320b8330013efc0c7fcb51792453376a6"
+      },
+      "description": "Reconstruct the real history of code (goal, shipped vs in-flight, coupled files) from Codex, Claude Code, and Eigen transcripts, surfaced via the get-oriented skill - so agents stop guessing the story of code they didn't write this session",
+      "version": "0.2.0",
+      "category": "productivity",
+      "homepage": "https://github.com/agent-sh/orientation"
     }
   ]
 }

--- a/scripts/plugins.txt
+++ b/scripts/plugins.txt
@@ -13,6 +13,7 @@ learn
 mojo
 next-task
 onboard
+orientation
 perf
 prepare-delivery
 repo-intel


### PR DESCRIPTION
## Summary

Adds **orientation** to the marketplace. It reconstructs the real history of code (goal, shipped vs in-flight, coupled files) from Codex, Claude Code, and Eigen transcripts and surfaces it via the `get-oriented` skill - so agents stop guessing the story of code they didn't write this session.

## Entry

- `name: orientation`, `category: productivity`, `homepage: github.com/agent-sh/orientation`
- Pinned to `v0.2.0` / commit `417d496320b8330013efc0c7fcb51792453376a6` (the dereferenced tag commit, verified present on the remote)
- Mirrored in `scripts/plugins.txt`

## Why now

`agent-sh/orientation` just shipped `v0.2.0`, which makes it installable as a Claude Code plugin: it has `.claude-plugin/plugin.json`, an auto-discovered `skills/get-oriented/`, and declarative `hooks/hooks.json` that run the bundled engine via `${CLAUDE_PLUGIN_ROOT}/src` and write state to `${CLAUDE_PLUGIN_DATA}`. The engine is dependency-free, so `/plugin install` needs no npm step. (Earlier it was npm-only and would have installed as an inert package.)

## Verification

- `scripts/pin-marketplace.js --dry-run` independently resolves `orientation -> v0.2.0 (417d496320)`, matching the pin.
- Marketplace contract tests pass (immutable commit pin, unique names mirrored in `plugins.txt`).
- Full agentsys suite green: 87 suites, 3517 passed.

After merge, users install with:

```
/plugin marketplace add agent-sh/agentsys
/plugin install orientation@agentsys
```