### PR TITLE
Add MiniMax thinking modes to OpenCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Added model-aware MiniMax thinking options in the OpenCode plugin without fixed token budgets.
+
+### Tests
+
+- Added coverage for MiniMax-M3 adaptive and disabled modes and MiniMax-M2.7 always-on behavior.
+
 ## [6.0.1] - 2026-07-22
 
 ### Security

--- a/__tests__/opencode-plugin-thinking.test.js
+++ b/__tests__/opencode-plugin-thinking.test.js
@@ -1,0 +1,66 @@
+const fs = require('fs');
+const Module = require('module');
+const path = require('path');
+const ts = require('typescript');
+
+function loadAgentSysPlugin() {
+  const pluginPath = path.join(__dirname, '../adapters/opencode-plugin/index.ts');
+  const source = fs.readFileSync(pluginPath, 'utf-8');
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020
+    },
+    fileName: pluginPath
+  });
+  const pluginModule = new Module(pluginPath, module);
+  pluginModule.filename = pluginPath;
+  pluginModule.paths = module.paths;
+  pluginModule._compile(compiled.outputText, pluginPath);
+  return pluginModule.exports.AgentSysPlugin;
+}
+
+describe('OpenCode MiniMax thinking configuration', () => {
+  let chatParams;
+
+  beforeAll(async () => {
+    const plugin = await loadAgentSysPlugin()({ directory: process.cwd() });
+    chatParams = plugin['chat.params'];
+  });
+
+  it('uses adaptive thinking for MiniMax-M3 with a positive agent budget', async () => {
+    const output = {};
+
+    await chatParams({
+      agent: 'implementation-agent',
+      model: { providerID: 'minimax', id: 'MiniMax-M3' }
+    }, output);
+
+    expect(output.options.thinking).toEqual({ type: 'adaptive' });
+    expect(output.options.thinking).not.toHaveProperty('budgetTokens');
+  });
+
+  it('disables thinking for MiniMax-M3 with a zero agent budget', async () => {
+    const output = {};
+
+    await chatParams({
+      agent: 'simple-fixer',
+      model: { providerID: 'minimax', id: 'MiniMax-M3' }
+    }, output);
+
+    expect(output.options.thinking).toEqual({ type: 'disabled' });
+    expect(output.options.thinking).not.toHaveProperty('budgetTokens');
+  });
+
+  it('preserves the always-on defaults for MiniMax-M2.7', async () => {
+    const output = { options: { existing: true } };
+
+    await chatParams({
+      agent: 'implementation-agent',
+      model: { providerID: 'minimax', id: 'MiniMax-M2.7' }
+    }, output);
+
+    expect(output).toEqual({ options: { existing: true } });
+    expect(output.options).not.toHaveProperty('thinking');
+  });
+});

--- a/adapters/opencode-plugin/index.ts
+++ b/adapters/opencode-plugin/index.ts
@@ -49,6 +49,26 @@ const AGENT_THINKING_CONFIG: Record<string, { budget: number; description: strin
   "skills-enhancer": { budget: 16000, description: "Skill prompt review" },
 }
 
+// MiniMax model capabilities do not use fixed thinking token budgets.
+function applyMiniMaxThinking(
+  modelID: string,
+  budget: number,
+  output: { options?: Record<string, unknown> }
+): void {
+  const normalizedModelID = (modelID || "").toLowerCase()
+
+  if (normalizedModelID === "minimax-m3") {
+    output.options = output.options || {}
+    output.options.thinking = {
+      type: budget > 0 ? "adaptive" : "disabled"
+    }
+    return
+  }
+
+  // MiniMax-M2.7 keeps its default always-on thinking behavior.
+  if (normalizedModelID === "minimax-m2.7") return
+}
+
 // Project script patterns for failure detection
 const PROJECT_SCRIPT_PATTERNS: RegExp[] = [
   /\bnpm\s+test\b/,
@@ -143,25 +163,28 @@ export const AgentSysPlugin: Plugin = async (ctx) => {
       // Check if this is one of our agents
       const config = AGENT_THINKING_CONFIG[agentName]
 
-      if (config && config.budget > 0) {
+      if (config) {
         // Detect provider and apply appropriate thinking config
         const providerID = input.model?.providerID || ""
+        const modelID = input.model?.id || ""
 
-        if (providerID.includes("anthropic") || providerID.includes("bedrock")) {
+        if (providerID.toLowerCase().includes("minimax")) {
+          applyMiniMaxThinking(modelID, config.budget, output)
+        } else if (config.budget > 0 && (providerID.includes("anthropic") || providerID.includes("bedrock"))) {
           // Anthropic-style thinking
           output.options = output.options || {}
           output.options.thinking = {
             type: "enabled",
             budgetTokens: config.budget
           }
-        } else if (providerID.includes("openai") || providerID.includes("azure")) {
+        } else if (config.budget > 0 && (providerID.includes("openai") || providerID.includes("azure"))) {
           // OpenAI-style reasoning
           output.options = output.options || {}
           const effort = config.budget >= 16000 ? "high" :
                         config.budget >= 12000 ? "medium" : "low"
           output.options.reasoningEffort = effort
           output.options.reasoningSummary = "auto"
-        } else if (providerID.includes("google")) {
+        } else if (config.budget > 0 && providerID.includes("google")) {
           // Google Gemini thinking
           output.options = output.options || {}
           output.options.thinkingConfig = {

--- a/agent-docs/OPENCODE-REFERENCE.md
+++ b/agent-docs/OPENCODE-REFERENCE.md
@@ -513,6 +513,9 @@ OpenCode supports thinking/reasoning across **multiple providers** with differen
 | **Google Gemini** | `low`, `high`, `max` | `thinkingConfig: { includeThoughts: true, thinkingBudget: 16000 }` |
 | **Amazon Bedrock** | `high`, `max` | `reasoningConfig: { type: "enabled", budgetTokens: 16000 }` |
 | **Groq** | `none`, `low`, `medium`, `high` | `includeThoughts: true, thinkingLevel: "high"` |
+| **MiniMax** | `adaptive`, `disabled` (MiniMax-M3); always on (MiniMax-M2.7) | `thinking: { type: "adaptive" }` or `thinking: { type: "disabled" }`; no fixed token budget |
+
+The AgentSys hook selects `adaptive` for MiniMax-M3 agents with a positive thinking tier and `disabled` for zero-budget agents. It leaves MiniMax-M2.7 options unchanged because that model's thinking mode is always on.
 
 ### Configuring Extended Thinking
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "agentsys-dev": "bin/dev-cli.js"
       },
       "devDependencies": {
-        "jest": "^29.7.0"
+        "jest": "^29.7.0",
+        "typescript": "^5.9.2"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -3494,6 +3495,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "node": ">=18.0.0"
   },
   "devDependencies": {
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "typescript": "^5.9.2"
   },
   "workspaces": [
     "lib"


### PR DESCRIPTION
Reason: Apply the supported MiniMax thinking behavior per model in the OpenCode chat hook.

Changes:
- Use adaptive or disabled thinking for MiniMax-M3 based on the agent thinking tier without a fixed token budget.
- Preserve MiniMax-M2.7's always-on default behavior.
- Add focused plugin coverage and reference documentation for both model behaviors.

Checks:
- `npm test -- --runInBand __tests__/opencode-plugin-thinking.test.js`
- `git diff --check origin/main...HEAD`
- Secret scan of the committed upstream diff (no matches)
