### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      security-and-patches:
+        update-types: [minor, patch]


### PR DESCRIPTION
Repo carries open Dependabot alerts but no config → no fix PRs ever proposed (flagged in daily external-activity report). Weekly, grouped minors/patches.