### PR TITLE
fix: spawn Claude plugin CLI via execFileSync on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+- Claude plugin marketplace/install/update/uninstall in `bin/cli.js` now spawn via `execFileSync` with an argv array (no shell) and resolve `claude.cmd` on Windows, where `execFileSync` does not apply PATHEXT.
+
 ## [6.0.1] - 2026-07-22
 
 ### Security

--- a/__tests__/cli-args.test.js
+++ b/__tests__/cli-args.test.js
@@ -6,7 +6,7 @@ const path = require('path');
 const fs = require('fs');
 
 // Import parseArgs directly from cli.js (now exported for testing)
-const { parseArgs, VALID_TOOLS } = require('../bin/cli.js');
+const { parseArgs, VALID_TOOLS, claudeExecutable } = require('../bin/cli.js');
 
 describe('CLI argument parsing', () => {
   // Save original process.exit and restore after each test
@@ -194,6 +194,17 @@ describe('VALID_TOOLS constant', () => {
   });
 });
 
+describe('claudeExecutable', () => {
+  test('uses claude.cmd on win32 because execFileSync skips PATHEXT', () => {
+    expect(claudeExecutable('win32')).toBe('claude.cmd');
+  });
+
+  test('uses extensionless claude on posix', () => {
+    expect(claudeExecutable('linux')).toBe('claude');
+    expect(claudeExecutable('darwin')).toBe('claude');
+  });
+});
+
 describe('CLI integration', () => {
   const cliPath = path.join(__dirname, '..', 'bin', 'cli.js');
   const cliSource = fs.readFileSync(cliPath, 'utf8');
@@ -234,6 +245,14 @@ describe('CLI integration', () => {
 
   test('cli.js has installForKiro function', () => {
     expect(cliSource.includes('function installForKiro(')).toBe(true);
+  });
+
+  test('claude plugin commands use execFileSync without a shell', () => {
+    expect(cliSource).toContain('function runClaudePlugin');
+    expect(cliSource).toContain('execFileSync(claudeExecutable()');
+    expect(cliSource).not.toMatch(/execSync\(`claude plugin/);
+    expect(cliSource).not.toMatch(/execSync\('claude plugin/);
+    expect(cliSource).toContain("platform === 'win32' ? 'claude.cmd' : 'claude'");
   });
 });
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -63,6 +63,21 @@ function commandExists(cmd) {
   }
 }
 
+/**
+ * Resolve the Claude Code CLI executable.
+ * execFileSync does not apply PATHEXT, so the npm global shim is `claude.cmd` on Windows.
+ */
+function claudeExecutable(platform = process.platform) {
+  return platform === 'win32' ? 'claude.cmd' : 'claude';
+}
+
+/**
+ * Run `claude plugin …` without a shell. Args are passed as an argv array.
+ */
+function runClaudePlugin(args) {
+  execFileSync(claudeExecutable(), ['plugin', ...args], { stdio: 'pipe' });
+}
+
 function copyDirRecursive(src, dest) {
   fs.mkdirSync(dest, { recursive: true });
   const entries = fs.readdirSync(src, { withFileTypes: true });
@@ -1069,13 +1084,13 @@ async function installPlugin(nameWithVersion, args) {
       }
       // Claude uses marketplace install
       if (commandExists('claude')) {
-        try { execSync('claude plugin marketplace add agent-sh/agentsys', { stdio: 'pipe' }); } catch {}
+        try { runClaudePlugin(['marketplace', 'add', 'agent-sh/agentsys']); } catch {}
         for (const depName of toFetch) {
           if (!/^[a-z0-9][a-z0-9-]*$/.test(depName)) continue;
           try {
-            execSync(`claude plugin install ${depName}@agentsys`, { stdio: 'pipe' });
+            runClaudePlugin(['install', `${depName}@agentsys`]);
           } catch {
-            try { execSync(`claude plugin update ${depName}@agentsys`, { stdio: 'pipe' }); } catch {}
+            try { runClaudePlugin(['update', `${depName}@agentsys`]); } catch {}
           }
         }
       }
@@ -1138,7 +1153,7 @@ function removePlugin(name) {
   // Remove from platforms
   if (platforms.includes('claude') && commandExists('claude')) {
     try {
-      execSync(`claude plugin uninstall ${name}@agentsys`, { stdio: 'pipe' });
+      runClaudePlugin(['uninstall', `${name}@agentsys`]);
       console.log(`  Removed from Claude Code: ${name}`);
     } catch {}
   }
@@ -1244,7 +1259,7 @@ function installForClaude() {
     // Add GitHub marketplace
     console.log('Adding marketplace...');
     try {
-      execSync('claude plugin marketplace add agent-sh/agentsys', { stdio: 'pipe' });
+      runClaudePlugin(['marketplace', 'add', 'agent-sh/agentsys']);
     } catch {
       // May already exist
     }
@@ -1253,22 +1268,22 @@ function installForClaude() {
     const plugins = discovery.discoverPlugins(PACKAGE_DIR);
     const failedPlugins = [];
     for (const plugin of plugins) {
-      // Validate plugin name before shell use (prevents injection)
+      // Skip names that are not safe plugin IDs
       if (!/^[a-z0-9][a-z0-9-]*$/.test(plugin)) continue;
       console.log(`  Installing ${plugin}...`);
       // Remove pre-rename plugin ID to prevent dual loading on upgrade
       try {
-        execSync(`claude plugin uninstall ${plugin}@awesome-slash`, { stdio: 'pipe' });
+        runClaudePlugin(['uninstall', `${plugin}@awesome-slash`]);
       } catch {
         // Not installed under old name
       }
       try {
         // Try install first
-        execSync(`claude plugin install ${plugin}@agentsys`, { stdio: 'pipe' });
+        runClaudePlugin(['install', `${plugin}@agentsys`]);
       } catch {
         // If install fails (already installed), try update
         try {
-          execSync(`claude plugin update ${plugin}@agentsys`, { stdio: 'pipe' });
+          runClaudePlugin(['update', `${plugin}@agentsys`]);
         } catch {
           failedPlugins.push(plugin);
         }
@@ -1307,19 +1322,19 @@ function installForClaudeDevelopment() {
   // Remove marketplace plugins first
   console.log('Removing marketplace plugins...');
   try {
-    execSync('claude plugin marketplace remove agent-sh/agentsys', { stdio: 'pipe' });
+    runClaudePlugin(['marketplace', 'remove', 'agent-sh/agentsys']);
     console.log('  [OK] Removed marketplace');
   } catch {
     // May not exist
   }
 
   for (const plugin of plugins) {
-    // Validate plugin name before shell use (prevents injection)
+    // Skip names that are not safe plugin IDs
     if (!/^[a-z0-9][a-z0-9-]*$/.test(plugin)) continue;
     // Uninstall both current and pre-rename plugin IDs
     for (const suffix of ['agentsys', 'awesome-slash']) {
       try {
-        execSync(`claude plugin uninstall ${plugin}@${suffix}`, { stdio: 'pipe' });
+        runClaudePlugin(['uninstall', `${plugin}@${suffix}`]);
         console.log(`  [OK] Uninstalled ${plugin}@${suffix}`);
       } catch {
         // May not be installed
@@ -2288,5 +2303,7 @@ module.exports = {
   resolvePluginSource,
   parseGitHubSource,
   installForCursor,
-  installForKiro
+  installForKiro,
+  claudeExecutable,
+  runClaudePlugin
 };


### PR DESCRIPTION
## Summary

Windows-safe follow-up to #388. That PR correctly dropped the shell for interpolated `claude plugin …` calls, but `execFileSync('claude', …)` does not apply PATHEXT, so the npm global shim (`claude.cmd`) is not found on Windows. Those failures are swallowed by existing `catch {}` blocks, so install/uninstall can report `[OK]` without touching Claude Code.

This change:

- Routes every `claude plugin` invocation (including the constant marketplace add/remove calls) through `runClaudePlugin()`, which uses `execFileSync` with an argv array.
- Resolves `claude.cmd` on `win32`, matching the existing `bump-version.js` PATHEXT workaround.
- Keeps the existing plugin-name allowlist (`/^[a-z0-9][a-z0-9-]*$/`).
- Adds unit tests for the Windows shim and a source-level guard against new shell interpolations.

## Test plan

- [x] `npx jest __tests__/cli-args.test.js __tests__/cli-subcommands.test.js`
- [ ] Confirm `agentsys install <plugin> --tool claude` still works on POSIX when `claude` is on PATH

Related: #388