### PR TITLE
ci: run the test job on windows-latest too

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Check every text file out with LF, on Windows too.
+#
+# scripts/generate-docs.js, scripts/gen-adapters.js and several tests compare
+# generated content against what is on disk byte for byte. Git's Windows default
+# converts to CRLF on checkout, which makes every one of those comparisons fail:
+# generated sections read as permanently stale and line-split parsers keep a
+# trailing \r on each value.
+* text=auto eol=lf
+
+*.png binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,14 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # Windows is not decoration here: the CLI resolves executables through
+    # where.exe, and a .cmd shim cannot be spawned directly since the
+    # CVE-2024-27980 fix, so that code path is only ever exercised on win32.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/__tests__/atomic-write.test.js
+++ b/__tests__/atomic-write.test.js
@@ -309,10 +309,14 @@ describe('atomic-write', () => {
 
     it('throws on read-only directory', () => {
       if (isWindows) {
-        // On Windows, we can test by trying to write to a system directory
-        // that requires admin privileges
-        const systemPath = 'C:\\Windows\\System32\\atomic-test-file.txt';
-        expect(() => writeFileAtomic(systemPath, 'test')).toThrow();
+        // A System32 write is not a reliable refusal: anything elevated - a CI
+        // runner included - succeeds and leaves the file behind. Use a parent
+        // that cannot hold children at all, which is refused whatever the
+        // account can do.
+        const notADirectory = path.join(tempDir, 'plain-file');
+        fs.writeFileSync(notADirectory, 'a file, not a directory');
+
+        expect(() => writeFileAtomic(path.join(notADirectory, 'file.txt'), 'test')).toThrow();
         return;
       }
 

--- a/__tests__/bump-version.test.js
+++ b/__tests__/bump-version.test.js
@@ -104,12 +104,21 @@ describe('bump-version', () => {
       // `agentsys-dev bump` needs the same hop as the rest of the CLI.
       const { execFileSync } = require('child_process');
       const platform = process.platform;
+      // A real Windows host has COMSPEC set to an absolute path, so it is pinned
+      // here as well - otherwise the expected shell differs per host.
+      const comspec = process.env.comspec;
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      process.env.comspec = 'cmd.exe';
 
       try {
         expect(main(['3.7.3'])).toBe(0);
       } finally {
         Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+        if (comspec === undefined) {
+          delete process.env.comspec;
+        } else {
+          process.env.comspec = comspec;
+        }
       }
 
       expect(execFileSync).toHaveBeenCalledWith(

--- a/__tests__/cli-args.test.js
+++ b/__tests__/cli-args.test.js
@@ -236,13 +236,15 @@ describe('claudeSpawnPlan', () => {
   test('routes a batch shim through cmd.exe, which execFileSync cannot spawn', () => {
     // Node's src disallows direct .bat/.cmd spawning since the CVE-2024-27980
     // fix, so a shim handed to execFileSync fails with EINVAL.
+    // comspec is passed rather than left to the environment: a real Windows host
+    // has COMSPEC set to an absolute path, which would not match a bare cmd.exe.
     const shim = 'C:\\npm\\claude.cmd';
-    expect(claudeSpawnPlan(shim, args, undefined, 'win32')).toEqual({
+    expect(claudeSpawnPlan(shim, args, 'cmd.exe', 'win32')).toEqual({
       file: 'cmd.exe',
       args: ['/d', '/s', '/c', '""C:\\npm\\claude.cmd" "plugin" "install" "agentsys-core@agentsys""'],
       verbatim: true
     });
-    expect(claudeSpawnPlan('C:\\npm\\claude.bat', args, undefined, 'win32').file).toBe('cmd.exe');
+    expect(claudeSpawnPlan('C:\\npm\\claude.bat', args, 'cmd.exe', 'win32').file).toBe('cmd.exe');
   });
 
   test('spawns a .cmd directly off Windows, where cmd.exe does not exist', () => {

--- a/__tests__/command-parser.test.js
+++ b/__tests__/command-parser.test.js
@@ -72,9 +72,11 @@ describe('resolveExecutableForPlatform', () => {
 
 describe('planShimSpawn', () => {
   // The .bat/.cmd rewrite is win32-only, so every shim case names the platform
-  // rather than depending on the host running the suite.
+  // rather than depending on the host running the suite. comspec is pinned for
+  // the same reason: a real Windows host has COMSPEC set to an absolute path, so
+  // reading it here would make the expected file differ per host.
   const plan = (executable, args, options = {}) =>
-    planShimSpawn(executable, args, { platform: 'win32', ...options });
+    planShimSpawn(executable, args, { platform: 'win32', comspec: 'cmd.exe', ...options });
 
   test('leaves a directly spawnable executable alone', () => {
     const args = ['run', 'bench'];
@@ -155,6 +157,25 @@ describe('planShimSpawn', () => {
   test('honours an explicit comspec', () => {
     expect(plan('npm.cmd', [], { comspec: 'C:\\Windows\\system32\\cmd.exe' }).file)
       .toBe('C:\\Windows\\system32\\cmd.exe');
+  });
+
+  test('falls back to COMSPEC, then to a bare cmd.exe', () => {
+    // Callers that have no comspec to pass get whatever Windows set, which is
+    // where a hardened box points COMSPEC somewhere other than System32.
+    const comspec = process.env.comspec;
+    try {
+      process.env.comspec = 'D:\\shells\\cmd.exe';
+      expect(planShimSpawn('npm.cmd', [], { platform: 'win32' }).file).toBe('D:\\shells\\cmd.exe');
+
+      delete process.env.comspec;
+      expect(planShimSpawn('npm.cmd', [], { platform: 'win32' }).file).toBe('cmd.exe');
+    } finally {
+      if (comspec === undefined) {
+        delete process.env.comspec;
+      } else {
+        process.env.comspec = comspec;
+      }
+    }
   });
 
   test('shimSpawnOptions adds windowsVerbatimArguments only for a shim', () => {

--- a/__tests__/marketplace-standalone-contract.test.js
+++ b/__tests__/marketplace-standalone-contract.test.js
@@ -44,7 +44,10 @@ test('marketplace plugin names are unique and mirrored in plugins.txt', () => {
   const pluginsTxt = fs
     .readFileSync(path.join(repoRoot, 'scripts/plugins.txt'), 'utf8')
     .trim()
-    .split('\n')
+    // Tolerate CRLF so a checkout's line endings cannot masquerade as a
+    // mismatched plugin name.
+    .split(/\r?\n/)
+    .map((line) => line.trim())
     .filter(Boolean);
 
   expect([...pluginsTxt].sort()).toEqual([...names].sort());

--- a/__tests__/marketplace-standalone-contract.test.js
+++ b/__tests__/marketplace-standalone-contract.test.js
@@ -45,9 +45,10 @@ test('marketplace plugin names are unique and mirrored in plugins.txt', () => {
     .readFileSync(path.join(repoRoot, 'scripts/plugins.txt'), 'utf8')
     .trim()
     // Tolerate CRLF so a checkout's line endings cannot masquerade as a
-    // mismatched plugin name.
+    // mismatched plugin name. Nothing else is normalised: the file is generated
+    // by scripts/generate-plugin-list.js, so stray whitespace in it is a defect
+    // this test should still catch.
     .split(/\r?\n/)
-    .map((line) => line.trim())
     .filter(Boolean);
 
   expect([...pluginsTxt].sort()).toEqual([...names].sort());

--- a/__tests__/perf-benchmark-runner.test.js
+++ b/__tests__/perf-benchmark-runner.test.js
@@ -115,12 +115,21 @@ describe('runBenchmark', () => {
     // win32-only, so the platform is faked rather than skipping off Windows.
     execFileSync.mockImplementation(() => 'output');
     const platform = process.platform;
+    // A real Windows host has COMSPEC set to an absolute path, so it is pinned
+    // here as well - otherwise the expected shell differs per host.
+    const comspec = process.env.comspec;
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    process.env.comspec = 'cmd.exe';
 
     try {
       runBenchmark('npm.cmd run bench', { allowShort: true });
     } finally {
       Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+      if (comspec === undefined) {
+        delete process.env.comspec;
+      } else {
+        process.env.comspec = comspec;
+      }
     }
 
     expect(execFileSync).toHaveBeenCalledWith(

--- a/__tests__/perf-profiling-runner.test.js
+++ b/__tests__/perf-profiling-runner.test.js
@@ -34,13 +34,22 @@ it('runs a batch shim profiler command through cmd.exe', () => {
 
   const runner = require('../lib/perf/profiling-runner');
   // The cmd.exe hop is win32-only, so fake the platform instead of skipping.
+  // comspec is pinned too: a real Windows host has COMSPEC set to an absolute
+  // path, which would not match a bare cmd.exe.
   const platform = process.platform;
+  const comspec = process.env.comspec;
   Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+  process.env.comspec = 'cmd.exe';
 
   try {
     expect(runner.runProfiling().ok).toBe(true);
   } finally {
     Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+    if (comspec === undefined) {
+      delete process.env.comspec;
+    } else {
+      process.env.comspec = comspec;
+    }
   }
 
   expect(execFileSync).toHaveBeenCalledWith(

--- a/tests/sources/custom-handler.test.js
+++ b/tests/sources/custom-handler.test.js
@@ -180,13 +180,22 @@ describe('Custom Handler', () => {
       // the probe would report an installed tool as unavailable either way.
       execFileSync.mockReturnValue('11.0.0');
       const platform = process.platform;
+      // A real Windows host has COMSPEC set to an absolute path, so it is pinned
+      // here as well - otherwise the expected shell differs per host.
+      const comspec = process.env.comspec;
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      process.env.comspec = 'cmd.exe';
 
       let result;
       try {
         result = customHandler.probeCLI('npx');
       } finally {
         Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+        if (comspec === undefined) {
+          delete process.env.comspec;
+        } else {
+          process.env.comspec = comspec;
+        }
       }
 
       expect(result.available).toBe(true);


### PR DESCRIPTION
## Why

The Windows-specific code in this repo has never run in CI:

- `where.exe` executable resolution and PATHEXT-aware lookups (`resolveExecutableForPlatform`)
- the `cmd.exe /d /s /c` routing that `.cmd` shims require since the CVE-2024-27980 fix (`planShimSpawn`)

Every defect in that area so far - #388, #389/#390, #391 - was found by a user hitting it on Windows or by reading the code. The unit tests fake `process.platform`, which proves the planner's arithmetic but never proves the plan actually spawns anything on a real Windows host.

## What

`test` becomes a 2-leg matrix: `ubuntu-latest` + `windows-latest`, `fail-fast: false` so a Windows-only failure does not mask the Linux result.

No source changes. This PR's job is to tell us whether the suite passes on Windows; anything it surfaces gets fixed on top.

## Test plan

The PR's own CI run is the test.