### PR TITLE
fix(windows): resolve dev-install's claude through where.exe, not a fixed suffix

### DIFF
--- a/__tests__/claude-executable.test.js
+++ b/__tests__/claude-executable.test.js
@@ -1,0 +1,124 @@
+/**
+ * Tests for Claude executable resolution in lib/utils/claude-executable.js
+ */
+
+const childProcess = require('child_process');
+
+const { pickClaudeExecutable, claudeExecutable } = require('../lib/utils/claude-executable');
+
+/**
+ * Load the module fresh with a faked platform and a stubbed execFileSync.
+ *
+ * The module destructures execFileSync at require time, so the spy has to exist
+ * before the require - and the cache has to be a fresh one per test, which a
+ * reset module gives for free.
+ */
+function loadWithPlatform(platform, whereImpl) {
+  const originalPlatform = process.platform;
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  jest.resetModules();
+  const execFileSync = jest.spyOn(childProcess, 'execFileSync').mockImplementation(whereImpl);
+  const loaded = require('../lib/utils/claude-executable');
+  return {
+    ...loaded,
+    execFileSync,
+    restore: () => Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+  };
+}
+
+describe('pickClaudeExecutable', () => {
+  test('uses plain claude on posix and ignores any where output', () => {
+    expect(pickClaudeExecutable('linux', '')).toBe('claude');
+    expect(pickClaudeExecutable('darwin', 'C:\\npm\\claude.cmd')).toBe('claude');
+  });
+
+  test('uses the npm global shim path that where.exe resolved', () => {
+    const shim = 'C:\\Users\\u\\AppData\\Roaming\\npm\\claude.cmd';
+    expect(pickClaudeExecutable('win32', `${shim}\r\n`)).toBe(shim);
+  });
+
+  test('uses claude.exe from the native installer instead of assuming .cmd', () => {
+    const native = 'C:\\Users\\u\\.local\\bin\\claude.exe';
+    expect(pickClaudeExecutable('win32', `${native}\r\n`)).toBe(native);
+  });
+
+  test('prefers claude.exe over a batch shim in either PATH order', () => {
+    const exe = 'C:\\Users\\u\\.local\\bin\\claude.exe';
+    const cmd = 'C:\\npm\\claude.cmd';
+    expect(pickClaudeExecutable('win32', `${exe}\r\n${cmd}\r\n`)).toBe(exe);
+    expect(pickClaudeExecutable('win32', `${cmd}\r\n${exe}\r\n`)).toBe(exe);
+  });
+
+  test('skips entries CreateProcess cannot launch', () => {
+    // npm ships an extensionless shell script and a .ps1 alongside the .cmd
+    const out = 'C:\\npm\\claude\r\nC:\\npm\\claude.ps1\r\nC:\\npm\\claude.cmd\r\n';
+    expect(pickClaudeExecutable('win32', out)).toBe('C:\\npm\\claude.cmd');
+  });
+
+  test('falls back to the cmd shim when nothing spawnable was resolved', () => {
+    expect(pickClaudeExecutable('win32', '')).toBe('claude.cmd');
+    expect(pickClaudeExecutable('win32', '  \r\n \r\n')).toBe('claude.cmd');
+    expect(pickClaudeExecutable('win32', undefined)).toBe('claude.cmd');
+    expect(pickClaudeExecutable('win32', 'C:\\npm\\claude.ps1\r\n')).toBe('claude.cmd');
+  });
+});
+
+describe('claudeExecutable', () => {
+  test('resolves and caches without a shell on this platform', () => {
+    const first = claudeExecutable();
+    expect(typeof first).toBe('string');
+    expect(first.length).toBeGreaterThan(0);
+    expect(claudeExecutable()).toBe(first);
+    if (process.platform !== 'win32') {
+      expect(first).toBe('claude');
+    }
+  });
+
+  test('does not ask where.exe anything off Windows', () => {
+    const mod = loadWithPlatform('linux', () => 'C:\\npm\\claude.cmd\r\n');
+    try {
+      expect(mod.claudeExecutable()).toBe('claude');
+      expect(mod.execFileSync).not.toHaveBeenCalled();
+    } finally {
+      mod.restore();
+    }
+  });
+
+  test('takes the win32 answer from where.exe and asks only once', () => {
+    const native = 'C:\\Users\\u\\.local\\bin\\claude.exe';
+    const mod = loadWithPlatform('win32', () => `${native}\r\n`);
+    try {
+      expect(mod.claudeExecutable()).toBe(native);
+      expect(mod.claudeExecutable()).toBe(native);
+      expect(mod.execFileSync).toHaveBeenCalledTimes(1);
+      expect(mod.execFileSync).toHaveBeenCalledWith('where.exe', ['claude'], expect.objectContaining({ encoding: 'utf8' }));
+    } finally {
+      mod.restore();
+    }
+  });
+
+  test('falls back to the shim mapping when where.exe itself fails', () => {
+    const mod = loadWithPlatform('win32', () => {
+      throw Object.assign(new Error('spawnSync where.exe ENOENT'), { code: 'ENOENT' });
+    });
+    try {
+      expect(mod.claudeExecutable()).toBe('claude.cmd');
+    } finally {
+      mod.restore();
+    }
+  });
+
+  test('resetClaudeExecutableCache forces a second resolution', () => {
+    let answer = 'C:\\npm\\claude.cmd\r\n';
+    const mod = loadWithPlatform('win32', () => answer);
+    try {
+      expect(mod.claudeExecutable()).toBe('C:\\npm\\claude.cmd');
+      answer = 'C:\\Users\\u\\.local\\bin\\claude.exe\r\n';
+      expect(mod.claudeExecutable()).toBe('C:\\npm\\claude.cmd');
+      mod.resetClaudeExecutableCache();
+      expect(mod.claudeExecutable()).toBe('C:\\Users\\u\\.local\\bin\\claude.exe');
+    } finally {
+      mod.restore();
+    }
+  });
+});

--- a/__tests__/cli-args.test.js
+++ b/__tests__/cli-args.test.js
@@ -6,7 +6,9 @@ const path = require('path');
 const fs = require('fs');
 
 // Import parseArgs directly from cli.js (now exported for testing)
-const { parseArgs, VALID_TOOLS, pickClaudeExecutable, claudeSpawnPlan, claudeExecutable } = require('../bin/cli.js');
+// Executable resolution moved to lib/utils/claude-executable.js - see
+// __tests__/claude-executable.test.js
+const { parseArgs, VALID_TOOLS, claudeSpawnPlan } = require('../bin/cli.js');
 
 describe('CLI argument parsing', () => {
   // Save original process.exit and restore after each test
@@ -188,43 +190,6 @@ describe('CLI argument parsing', () => {
   });
 });
 
-describe('pickClaudeExecutable', () => {
-  test('uses plain claude on posix and ignores any where output', () => {
-    expect(pickClaudeExecutable('linux', '')).toBe('claude');
-    expect(pickClaudeExecutable('darwin', 'C:\\npm\\claude.cmd')).toBe('claude');
-  });
-
-  test('uses the npm global shim path that where.exe resolved', () => {
-    const shim = 'C:\\Users\\u\\AppData\\Roaming\\npm\\claude.cmd';
-    expect(pickClaudeExecutable('win32', `${shim}\r\n`)).toBe(shim);
-  });
-
-  test('uses claude.exe from the native installer instead of assuming .cmd', () => {
-    const native = 'C:\\Users\\u\\.local\\bin\\claude.exe';
-    expect(pickClaudeExecutable('win32', `${native}\r\n`)).toBe(native);
-  });
-
-  test('prefers claude.exe over a batch shim in either PATH order', () => {
-    const exe = 'C:\\Users\\u\\.local\\bin\\claude.exe';
-    const cmd = 'C:\\npm\\claude.cmd';
-    expect(pickClaudeExecutable('win32', `${exe}\r\n${cmd}\r\n`)).toBe(exe);
-    expect(pickClaudeExecutable('win32', `${cmd}\r\n${exe}\r\n`)).toBe(exe);
-  });
-
-  test('skips entries CreateProcess cannot launch', () => {
-    // npm ships an extensionless shell script and a .ps1 alongside the .cmd
-    const out = 'C:\\npm\\claude\r\nC:\\npm\\claude.ps1\r\nC:\\npm\\claude.cmd\r\n';
-    expect(pickClaudeExecutable('win32', out)).toBe('C:\\npm\\claude.cmd');
-  });
-
-  test('falls back to the cmd shim when nothing spawnable was resolved', () => {
-    expect(pickClaudeExecutable('win32', '')).toBe('claude.cmd');
-    expect(pickClaudeExecutable('win32', '  \r\n \r\n')).toBe('claude.cmd');
-    expect(pickClaudeExecutable('win32', undefined)).toBe('claude.cmd');
-    expect(pickClaudeExecutable('win32', 'C:\\npm\\claude.ps1\r\n')).toBe('claude.cmd');
-  });
-});
-
 describe('claudeSpawnPlan', () => {
   const args = ['plugin', 'install', 'agentsys-core@agentsys'];
 
@@ -276,16 +241,6 @@ describe('claudeSpawnPlan', () => {
     // Nothing reparses an execFileSync argv, so it needs no metacharacter guard.
     expect(claudeSpawnPlan('claude', ['plugin', 'install', 'x&calc']).args)
       .toEqual(['plugin', 'install', 'x&calc']);
-  });
-
-  test('claudeExecutable resolves and caches without a shell on this platform', () => {
-    const first = claudeExecutable();
-    expect(typeof first).toBe('string');
-    expect(first.length).toBeGreaterThan(0);
-    expect(claudeExecutable()).toBe(first);
-    if (process.platform !== 'win32') {
-      expect(first).toBe('claude');
-    }
   });
 });
 

--- a/__tests__/dev-install.test.js
+++ b/__tests__/dev-install.test.js
@@ -3,6 +3,7 @@
  */
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const devInstallPath = path.join(__dirname, '..', 'scripts', 'dev-install.js');
@@ -280,6 +281,120 @@ describe('dev-install script', () => {
       });
 
       expect(require(devInstallPath).commandExists('claude')).toBe(false);
+    });
+  });
+
+  describe('installClaude external commands', () => {
+    const realPlatform = process.platform;
+    const realComspec = process.env.comspec;
+    const realHome = process.env.HOME;
+    const realUserProfile = process.env.USERPROFILE;
+    let home;
+
+    beforeEach(() => {
+      // installClaude writes under HOME - point it at a scratch dir so the run
+      // cannot touch the developer's own ~/.claude.
+      home = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-install-claude-'));
+      process.env.HOME = home;
+      process.env.USERPROFILE = home;
+      process.env.comspec = 'cmd.exe';
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true });
+      restoreEnv('HOME', realHome);
+      restoreEnv('USERPROFILE', realUserProfile);
+      restoreEnv('comspec', realComspec);
+      fs.rmSync(home, { recursive: true, force: true });
+      jest.resetModules();
+      jest.clearAllMocks();
+    });
+
+    function restoreEnv(name, value) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+
+    /**
+     * Run installClaude with a faked platform and a stubbed child_process.
+     *
+     * whereOutput is what `where.exe claude` answers, which is what decides the
+     * executable on win32; spawn is what every other command does, so a test can
+     * make the claude call fail the way a real spawn failure does.
+     */
+    function runInstallClaude(platform, { whereOutput = '', spawn = () => '' } = {}) {
+      Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+      jest.resetModules();
+      const childProcess = require('child_process');
+      const execFileSync = jest.spyOn(childProcess, 'execFileSync').mockImplementation((file, args, options) => {
+        if (/where\.exe$/i.test(file) && args[0] === 'claude') {
+          return whereOutput;
+        }
+        return spawn(file, args, options);
+      });
+      const logs = [];
+      const consoleLog = jest.spyOn(console, 'log').mockImplementation(msg => logs.push(String(msg)));
+      require(devInstallPath).installClaude();
+      consoleLog.mockRestore();
+      const claudeCalls = execFileSync.mock.calls.filter(([, args]) => args.includes('marketplace') || args.join(' ').includes('"marketplace"'));
+      return { execFileSync, logs, claudeCalls };
+    }
+
+    test('spawns the claude.exe where.exe resolved, with no cmd.exe hop', () => {
+      const native = 'C:\\Users\\u\\.local\\bin\\claude.exe';
+      const { claudeCalls, execFileSync } = runInstallClaude('win32', { whereOutput: `${native}\r\n` });
+
+      expect(claudeCalls).toEqual([[native, ['plugin', 'marketplace', 'remove', 'agent-sh/agentsys'], { stdio: 'pipe' }]]);
+      expect(execFileSync.mock.calls.some(([file]) => file === 'cmd.exe')).toBe(false);
+    });
+
+    test('routes the claude.cmd where.exe resolved through cmd.exe', () => {
+      const shim = 'C:\\npm\\claude.cmd';
+      const { claudeCalls } = runInstallClaude('win32', { whereOutput: `${shim}\r\n` });
+
+      expect(claudeCalls).toEqual([[
+        'cmd.exe',
+        ['/d', '/s', '/c', `""${shim}" "plugin" "marketplace" "remove" "agent-sh/agentsys""`],
+        { stdio: 'pipe', windowsVerbatimArguments: true }
+      ]]);
+    });
+
+    test('spawns plain claude off Windows', () => {
+      const { claudeCalls } = runInstallClaude('linux');
+
+      expect(claudeCalls).toEqual([['claude', ['plugin', 'marketplace', 'remove', 'agent-sh/agentsys'], { stdio: 'pipe' }]]);
+    });
+
+    test('reports a claude that could not be started at all', () => {
+      // A wrong executable used to be indistinguishable from nothing to remove:
+      // the catch swallowed it and the run claimed success having done nothing.
+      const { logs } = runInstallClaude('linux', {
+        spawn: (file, args) => {
+          if (args.includes('marketplace')) {
+            throw Object.assign(new Error('spawnSync claude ENOENT'), { code: 'ENOENT', status: null });
+          }
+          return '';
+        }
+      });
+
+      expect(logs.some(line => line.includes('[WARN]') && line.includes('Could not run claude') && line.includes('ENOENT'))).toBe(true);
+    });
+
+    test('stays quiet when claude ran and exited non-zero', () => {
+      // Nothing to remove is the normal case, not a failure worth a warning.
+      const { logs } = runInstallClaude('linux', {
+        spawn: (file, args) => {
+          if (args.includes('marketplace')) {
+            throw Object.assign(new Error('Command failed'), { status: 1 });
+          }
+          return '';
+        }
+      });
+
+      expect(logs.some(line => line.includes('[WARN]'))).toBe(false);
     });
   });
 

--- a/__tests__/dev-install.test.js
+++ b/__tests__/dev-install.test.js
@@ -383,6 +383,54 @@ describe('dev-install script', () => {
       expect(logs.some(line => line.includes('[WARN]') && line.includes('Could not run claude') && line.includes('ENOENT'))).toBe(true);
     });
 
+    test('reports a claude.cmd cmd.exe could not launch', () => {
+      // The shim host is the one this whole fix is about, and there the child is
+      // cmd.exe: it starts fine, so a shim it cannot launch shows up only as its
+      // 9009 exit code. status === null alone would never see it.
+      const { logs } = runInstallClaude('win32', {
+        whereOutput: 'C:\\npm\\claude.cmd\r\n',
+        spawn: (file, args) => {
+          if (args.join(' ').includes('"marketplace"')) {
+            throw Object.assign(new Error('Command failed'), { status: 9009 });
+          }
+          return '';
+        }
+      });
+
+      expect(logs.some(line => line.includes('[WARN]') && line.includes('C:\\npm\\claude.cmd') && line.includes('exit 9009'))).toBe(true);
+    });
+
+    test('stays quiet when a claude.cmd ran and exited non-zero', () => {
+      // Through cmd.exe as well, the shim's own exit code still means claude ran.
+      const { logs } = runInstallClaude('win32', {
+        whereOutput: 'C:\\npm\\claude.cmd\r\n',
+        spawn: (file, args) => {
+          if (args.join(' ').includes('"marketplace"')) {
+            throw Object.assign(new Error('Command failed'), { status: 1 });
+          }
+          return '';
+        }
+      });
+
+      expect(logs.some(line => line.includes('[WARN]'))).toBe(false);
+    });
+
+    test('9009 from a direct executable is the executable talking, not cmd.exe', () => {
+      // Only the shim route goes through cmd.exe, so 9009 from a .exe is just an
+      // exit code and has to stay a normal best-effort failure.
+      const { logs } = runInstallClaude('win32', {
+        whereOutput: 'C:\\Users\\u\\.local\\bin\\claude.exe\r\n',
+        spawn: (file, args) => {
+          if (args.includes('marketplace')) {
+            throw Object.assign(new Error('Command failed'), { status: 9009 });
+          }
+          return '';
+        }
+      });
+
+      expect(logs.some(line => line.includes('[WARN]'))).toBe(false);
+    });
+
     test('stays quiet when claude ran and exited non-zero', () => {
       // Nothing to remove is the normal case, not a failure worth a warning.
       const { logs } = runInstallClaude('linux', {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -20,7 +20,8 @@ const VERSION = require('../package.json').version;
 const PACKAGE_DIR = path.join(__dirname, '..');
 const discovery = require('../lib/discovery');
 const transforms = require('../lib/adapter-transforms');
-const { resolveExecutableForPlatform, planShimSpawn, shimSpawnOptions } = require('../lib/utils/command-parser');
+const { planShimSpawn, shimSpawnOptions, WINDOWS_BATCH_SHIM } = require('../lib/utils/command-parser');
+const { claudeExecutable } = require('../lib/utils/claude-executable');
 
 // Valid tool names
 const VALID_TOOLS = ['claude', 'opencode', 'codex', 'cursor', 'kiro'];
@@ -64,38 +65,8 @@ function commandExists(cmd) {
   }
 }
 
-// Extensions CreateProcess can launch directly. A .ps1 and an extensionless npm
-// shell script also show up in `where.exe` output but can never be spawned.
-const WINDOWS_DIRECT_EXEC = /\.(exe|com)$/i;
-// Batch shims need a cmd.exe hop: since the CVE-2024-27980 fix (Node 18.20.2 /
-// 20.12.2 / 21.7.3) src disallows direct .bat and .cmd spawning, so handing one
-// to execFileSync fails with EINVAL rather than running it.
-const WINDOWS_BATCH_SHIM = /\.(cmd|bat)$/i;
 // Arguments safe to hand to cmd.exe: no whitespace, no shell metacharacters.
 const CMD_SAFE_ARG = /^[A-Za-z0-9@._:\\/+-]+$/;
-
-/**
- * Pick the Claude Code executable from a `where.exe claude` result.
- *
- * execFileSync does not apply PATHEXT, so an extensionless 'claude' cannot be
- * spawned on Windows - but the suffix is not knowable either: the npm global
- * install provides claude.cmd while the native installer provides claude.exe.
- * Rank the directly launchable .exe/.com ahead of a batch shim regardless of
- * PATH order, since the shim costs an extra cmd.exe hop, and fall back to the
- * shim mapping. Kept pure so the win32 branch is testable off Windows.
- */
-function pickClaudeExecutable(platform, whereOutput) {
-  if (platform !== 'win32') {
-    return 'claude';
-  }
-  const candidates = String(whereOutput || '')
-    .split(/\r?\n/)
-    .map(line => line.trim())
-    .filter(Boolean);
-  return candidates.find(candidate => WINDOWS_DIRECT_EXEC.test(candidate))
-    || candidates.find(candidate => WINDOWS_BATCH_SHIM.test(candidate))
-    || resolveExecutableForPlatform('claude', platform);
-}
 
 /**
  * Build the file and argv for one Claude Code invocation.
@@ -115,26 +86,6 @@ function claudeSpawnPlan(executable, args, comspec, platform = process.platform)
     }
   }
   return planShimSpawn(executable, args, { comspec, platform });
-}
-
-let claudeBinCache;
-
-/**
- * Resolve the Claude Code executable once per process.
- */
-function claudeExecutable() {
-  if (claudeBinCache === undefined) {
-    let whereOutput = '';
-    if (process.platform === 'win32') {
-      try {
-        whereOutput = execFileSync('where.exe', ['claude'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
-      } catch {
-        // Fall back to the shim mapping below.
-      }
-    }
-    claudeBinCache = pickClaudeExecutable(process.platform, whereOutput);
-  }
-  return claudeBinCache;
 }
 
 /**
@@ -2425,7 +2376,5 @@ module.exports = {
   parseGitHubSource,
   installForCursor,
   installForKiro,
-  pickClaudeExecutable,
-  claudeSpawnPlan,
-  claudeExecutable
+  claudeSpawnPlan
 };

--- a/lib/utils/claude-executable.js
+++ b/lib/utils/claude-executable.js
@@ -1,0 +1,74 @@
+/**
+ * Resolution of the Claude Code executable, shared by every caller that spawns it.
+ *
+ * Lives here rather than in bin/cli.js because scripts/dev-install.js needs the
+ * same answer: a second resolution that guesses the Windows suffix drifts from
+ * this one the moment an install layout changes.
+ *
+ * @module lib/utils/claude-executable
+ */
+
+'use strict';
+
+const { execFileSync } = require('child_process');
+const { resolveExecutableForPlatform, WINDOWS_BATCH_SHIM } = require('./command-parser');
+
+// Extensions CreateProcess can launch directly. A .ps1 and an extensionless npm
+// shell script also show up in `where.exe` output but can never be spawned.
+const WINDOWS_DIRECT_EXEC = /\.(exe|com)$/i;
+
+/**
+ * Pick the Claude Code executable from a `where.exe claude` result.
+ *
+ * execFileSync does not apply PATHEXT, so an extensionless 'claude' cannot be
+ * spawned on Windows - but the suffix is not knowable either: the npm global
+ * install provides claude.cmd while the native installer provides claude.exe.
+ * Rank the directly launchable .exe/.com ahead of a batch shim regardless of
+ * PATH order, since the shim costs an extra cmd.exe hop, and fall back to the
+ * shim mapping. Kept pure so the win32 branch is testable off Windows.
+ */
+function pickClaudeExecutable(platform, whereOutput) {
+  if (platform !== 'win32') {
+    return 'claude';
+  }
+  const candidates = String(whereOutput || '')
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean);
+  return candidates.find(candidate => WINDOWS_DIRECT_EXEC.test(candidate))
+    || candidates.find(candidate => WINDOWS_BATCH_SHIM.test(candidate))
+    || resolveExecutableForPlatform('claude', platform);
+}
+
+let claudeBinCache;
+
+/**
+ * Resolve the Claude Code executable once per process.
+ */
+function claudeExecutable() {
+  if (claudeBinCache === undefined) {
+    let whereOutput = '';
+    if (process.platform === 'win32') {
+      try {
+        whereOutput = execFileSync('where.exe', ['claude'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+      } catch {
+        // Fall back to the shim mapping below.
+      }
+    }
+    claudeBinCache = pickClaudeExecutable(process.platform, whereOutput);
+  }
+  return claudeBinCache;
+}
+
+/**
+ * Drop the cached executable. Only for tests that fake the platform or where.exe.
+ */
+function resetClaudeExecutableCache() {
+  claudeBinCache = undefined;
+}
+
+module.exports = {
+  pickClaudeExecutable,
+  claudeExecutable,
+  resetClaudeExecutableCache
+};

--- a/lib/utils/command-parser.js
+++ b/lib/utils/command-parser.js
@@ -47,6 +47,10 @@ function resolveExecutableForPlatform(executable, platform = process.platform) {
     : executable;
 }
 
+// Batch shims need a cmd.exe hop: since the CVE-2024-27980 fix (Node 18.20.2 /
+// 20.12.2 / 21.7.3) src disallows direct .bat and .cmd spawning, so handing one
+// to execFileSync fails with EINVAL rather than running it. Exported because
+// callers that decide between executables have to know which ones cost the hop.
 const WINDOWS_BATCH_SHIM = /\.(cmd|bat)$/i;
 
 // Characters no amount of quoting carries through cmd.exe: % is expanded even
@@ -264,5 +268,6 @@ module.exports = {
   parseCommand,
   resolveExecutableForPlatform,
   planShimSpawn,
-  shimSpawnOptions
+  shimSpawnOptions,
+  WINDOWS_BATCH_SHIM
 };

--- a/scripts/dev-install.js
+++ b/scripts/dev-install.js
@@ -33,6 +33,7 @@ const {
   planShimSpawn,
   shimSpawnOptions
 } = require(path.join(SOURCE_DIR, 'lib', 'utils', 'command-parser'));
+const { claudeExecutable } = require(path.join(SOURCE_DIR, 'lib', 'utils', 'claude-executable'));
 
 // Target directories
 const HOME = process.env.HOME || process.env.USERPROFILE;
@@ -62,11 +63,12 @@ function log(msg) {
 /**
  * Run one external command with an argv list instead of a shell string.
  *
- * The commands here (`claude`, `npm`) are .cmd shims on Windows, which need two
- * separate fixes: resolveExecutableForPlatform supplies the extension that
- * execFileSync will not look up itself, and planShimSpawn routes the shim
- * through cmd.exe, since Node has refused to spawn .cmd directly since the
- * CVE-2024-27980 fix. Plugin names reach this from discovery on disk, so they
+ * A Windows command needs two separate fixes: resolveExecutableForPlatform
+ * supplies the extension that execFileSync will not look up itself, and
+ * planShimSpawn routes a .cmd or .bat through cmd.exe, since Node has refused to
+ * spawn those directly since the CVE-2024-27980 fix. An executable that already
+ * carries an extension - what claudeExecutable() returns - passes through the
+ * first step untouched. Plugin names reach this from discovery on disk, so they
  * stay argv elements - a shell string would make a directory named `a & b` a
  * second command.
  */
@@ -288,12 +290,29 @@ function installClaude() {
     return false;
   }
 
+  // Ask where.exe which claude this is instead of assuming a suffix: the npm
+  // global install ships claude.cmd and the native installer ships claude.exe.
+  const claudeBin = claudeExecutable();
+
+  // The removals below are best-effort - a marketplace that was never added and
+  // a plugin that was never installed both exit non-zero, and that is fine. A
+  // claude that could not be started at all is not: it would make every removal
+  // a silent no-op, so say so once.
+  let spawnFailureReported = false;
+  const reportIfNeverRan = (err) => {
+    // execFileSync sets a numeric status when the child ran and exited non-zero;
+    // a spawn failure leaves status null and carries the errno code instead.
+    if (typeof err.status === 'number' || spawnFailureReported) return;
+    spawnFailureReported = true;
+    log(`  [WARN] Could not run ${claudeBin} (${err.code || err.message}); leaving any marketplace or installed plugins in place`);
+  };
+
   // Remove marketplace plugins first
   try {
-    runCommand('claude', ['plugin', 'marketplace', 'remove', 'agent-sh/agentsys'], { stdio: 'pipe' });
+    runCommand(claudeBin, ['plugin', 'marketplace', 'remove', 'agent-sh/agentsys'], { stdio: 'pipe' });
     log('  Removed marketplace');
-  } catch {
-    // May not exist
+  } catch (err) {
+    reportIfNeverRan(err);
   }
 
   for (const plugin of PLUGINS) {
@@ -301,9 +320,9 @@ function installClaude() {
     // Uninstall both current and pre-rename plugin IDs
     for (const suffix of ['agentsys', 'awesome-slash']) {
       try {
-        runCommand('claude', ['plugin', 'uninstall', `${plugin}@${suffix}`], { stdio: 'pipe' });
-      } catch {
-        // May not be installed
+        runCommand(claudeBin, ['plugin', 'uninstall', `${plugin}@${suffix}`], { stdio: 'pipe' });
+      } catch (err) {
+        reportIfNeverRan(err);
       }
     }
   }
@@ -656,4 +675,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { main, runCommand, commandExists };
+module.exports = { main, runCommand, commandExists, installClaude };

--- a/scripts/dev-install.js
+++ b/scripts/dev-install.js
@@ -31,7 +31,8 @@ const transforms = require(path.join(SOURCE_DIR, 'lib', 'adapter-transforms'));
 const {
   resolveExecutableForPlatform,
   planShimSpawn,
-  shimSpawnOptions
+  shimSpawnOptions,
+  WINDOWS_BATCH_SHIM
 } = require(path.join(SOURCE_DIR, 'lib', 'utils', 'command-parser'));
 const { claudeExecutable } = require(path.join(SOURCE_DIR, 'lib', 'utils', 'claude-executable'));
 
@@ -55,6 +56,9 @@ const AGENTSYS_DIR = path.join(HOME, '.agentsys');
 
 // Discover plugins from filesystem
 const PLUGINS = discovery.discoverPlugins(SOURCE_DIR);
+
+// cmd.exe's exit code for a command it could not find or launch.
+const CMD_NOT_RECOGNIZED = 9009;
 
 function log(msg) {
   console.log(`[dev-install] ${msg}`);
@@ -294,6 +298,10 @@ function installClaude() {
   // global install ships claude.cmd and the native installer ships claude.exe.
   const claudeBin = claudeExecutable();
 
+  // A .cmd claude is launched through cmd.exe rather than directly, so the two
+  // failure shapes below differ by which process is the one that fails.
+  const viaCmdShim = process.platform === 'win32' && WINDOWS_BATCH_SHIM.test(claudeBin);
+
   // The removals below are best-effort - a marketplace that was never added and
   // a plugin that was never installed both exit non-zero, and that is fine. A
   // claude that could not be started at all is not: it would make every removal
@@ -301,10 +309,16 @@ function installClaude() {
   let spawnFailureReported = false;
   const reportIfNeverRan = (err) => {
     // execFileSync sets a numeric status when the child ran and exited non-zero;
-    // a spawn failure leaves status null and carries the errno code instead.
-    if (typeof err.status === 'number' || spawnFailureReported) return;
+    // a spawn failure leaves status null and carries the errno code instead. That
+    // alone misses the shim host: there the child is cmd.exe, which starts fine
+    // and reports a shim it could not launch as exit 9009, its code for "not
+    // recognized as an internal or external command".
+    const neverRan = typeof err.status !== 'number'
+      || (viaCmdShim && err.status === CMD_NOT_RECOGNIZED);
+    if (!neverRan || spawnFailureReported) return;
     spawnFailureReported = true;
-    log(`  [WARN] Could not run ${claudeBin} (${err.code || err.message}); leaving any marketplace or installed plugins in place`);
+    const reason = err.code || (typeof err.status === 'number' ? `exit ${err.status}` : err.message);
+    log(`  [WARN] Could not run ${claudeBin} (${reason}); leaving any marketplace or installed plugins in place`);
   };
 
   // Remove marketplace plugins first


### PR DESCRIPTION
## Why

Follow-up on the review of #393. That PR turned dev-install's four external commands into argv spawns, and the two `claude` ones resolved the executable with `resolveExecutableForPlatform`, which maps a bare `claude` to `claude.cmd` on win32.

That is exactly the assumption #390 removed from `bin/cli.js`. The npm global install does ship `claude.cmd`, but the native installer ships `claude.exe`. On such a host:

- `commandExists('claude')` passes, because `where.exe` applies PATHEXT and finds `claude.exe`;
- the spawn of `claude.cmd` then fails, because `execFileSync` does not;
- both call sites (`scripts/dev-install.js:293` and `:304`) caught the error and discarded it.

So the marketplace removal and every plugin uninstall silently did nothing, and the run still reported success - a regression against the old `execSync`, which got PATHEXT for free from cmd.exe.

## What changed

- The `where.exe`-based pick moves out of `bin/cli.js` into `lib/utils/claude-executable.js`. `scripts/dev-install.js` needs the same answer, and a second resolution that guesses the suffix drifts from the first the moment an install layout changes. `cli.js` imports it instead of keeping a copy, and stops exporting the two functions it no longer owns.
- `installClaude` resolves once via `claudeExecutable()` and passes that to both `runCommand` calls.
- The empty catches become a warning. Both removals are best-effort - nothing to remove exits non-zero, and that is normal - so the two cases are told apart by what `execFileSync` reports: a numeric `status` means claude ran and refused, while a spawn failure leaves `status` null and carries the errno `code`. Only the second is worth a line, and only the first one of them.
- `WINDOWS_BATCH_SHIM` is exported from `lib/utils/command-parser.js`, carrying the CVE-2024-27980 note it had in `cli.js`, since callers that choose between executables have to know which ones cost a cmd.exe hop.

## Tests

`__tests__/claude-executable.test.js` (new): the six resolution cases moved with the module, plus where.exe being asked exactly once, not asked at all off Windows, the fallback when where.exe itself fails, and the cache reset.

`__tests__/dev-install.test.js`: five tests running `installClaude` against a stubbed `child_process` and a scratch `HOME`, covering the native `.exe` spawning directly with no cmd.exe call, the `.cmd` shim taking the hop, the posix path, the warning on a spawn failure, and silence on a plain non-zero exit.

Local gate: `npm test` 89 suites / 3584 passed / 39 skipped, `npm run validate`, `gen-docs:check`, `gen-adapters:check`, `expand-templates:check` all clean.