### PR TITLE
chore: release v6.0.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "agentsys",
   "description": "26 specialized plugins for AI workflow automation - task orchestration, PR workflow, slop detection, code review, drift detection, enhancement analysis, documentation sync, unified static analysis, durable memory, negative behavior memory, skill and system prompt curation, perf investigations, topic research, agent config linting, cross-tool AI consultation, structured AI debate, workflow pattern learning, codebase onboarding, contributor guidance, Zig language support, Mojo language support, and Ada/SPARK language support",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "owner": {
     "name": "Avi Fenesh",
     "url": "https://github.com/avifenesh"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Professional-grade slash commands for Claude Code with cross-platform support",
   "keywords": [
     "workflow",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [6.0.2] - 2026-08-17
+
+### Added
+
+- CI runs the jest suite on `windows-latest` as well as Linux, with `fail-fast` disabled so a Windows-only failure does not hide the Linux result (#392). The Windows-specific paths in this repo - `where.exe` executable resolution, PATHEXT-aware lookups, and the `cmd.exe` routing `.cmd` shims have needed since the CVE-2024-27980 fix - had never been exercised by CI: every regression in them so far was found by a user on Windows or by reading the code, which is why one defect class took three PRs to close.
+- Dependabot configuration: weekly npm checks with minor and patch updates grouped into one PR (#385).
+
+### Changed
+
+- `jest` 29.7.0 -> 30.4.2 (#387). Jest 30 treats `--testPathPattern` as a fatal deprecation, so the targeted-test commands in the checklists now pass `--testPathPatterns`.
 
 ### Removed
 
@@ -16,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Claude plugin marketplace/install/update/uninstall in `bin/cli.js` now spawn via `execFileSync` with an argv array, so no plugin ID reaches a shell (#388).
+- Lockfile bump closing GHSA-5p4m-2wfm-xmqj in `js-yaml`, together with the remaining audit-fixable high-severity advisories (#386). Transitive dev dependencies; no manifest range changed.
+- Lockfile bump taking `brace-expansion` to 1.1.16, closing its high-severity ReDoS advisory (#383). Transitive dev dependency; no manifest range changed.
 
 ### Fixed
 
@@ -24,7 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `agentsys install` no longer reports `[OK] Installed ... successfully` when Claude Code rejected a plugin. It names the plugins that failed, with the errno when the shim could not be spawned at all, and how to retry. The same now applies when the `claude` CLI is not on PATH at all (`~/.claude` alone was enough to mark the platform as installed) and when a dependency id would be rejected. Such a plugin is also no longer recorded against `claude` in `installed.json` - `agentsys list` and `agentsys remove` read those platforms back - though a registration recorded by an earlier successful install is preserved, since a failed re-install is not evidence the first one never landed. The process now exits non-zero, matching the `--tool` path so `agentsys install x && ...` stops.
 - Windows: `agentsys-dev test`, `agentsys-dev bump`, `runBenchmark`, and `runProfiling` all handed a `.cmd` shim straight to `spawnSync`/`execFileSync`, which fails with `EINVAL` for the same reason the Claude shim did - `resolveExecutableForPlatform` turns `npm` into `npm.cmd` and `node_modules/.bin/vitest` into `vitest.cmd`, so every benchmark, profile, and dev test run died on Windows. These now route through `cmd.exe` via a shared `planShimSpawn` in `lib/utils/command-parser.js`, which `bin/cli.js` uses as well so the two mechanisms cannot drift apart. Unlike the Claude call sites, these carry user-written commands, so arguments are quoted for `cmd.exe` rather than rejected for containing whitespace or metacharacters; a literal `"`, `%`, CR or LF is still refused, in the executable as well as the arguments, since none survives `cmd.exe` intact - `bench\ncalc` would otherwise reach the command line, which `bin/cli.js` is shielded from only by its allowlist. The rewrite is win32-only: a repo-local `build.cmd` on Linux is spawnable as it stands, and routing it through a `cmd.exe` that is not there would only turn a working command into `ENOENT`. `agentsys-dev test` also prints the error it used to swallow, since a refused argument now reaches the user from there.
 - Windows: a custom source naming an npm-shipped CLI (`npx`, `pnpm`, `yarn`) was always probed as unavailable - `execFileSync` applies no PATHEXT, so the bare name raised `ENOENT`, and the `.cmd` it needs cannot be spawned directly either. `probeCLI` resolves the shim and routes it the same way.
+- Windows: `scripts/dev-install.js` ran all four of its external commands through `execSync`, i.e. through a shell (#393). `claude` and `npm` are `.cmd` shims there, so only the implicit `cmd.exe` hop made them work at all - anything but a shell string needs the explicit hop `planShimSpawn` builds, since Node has refused direct `.cmd` spawns since the CVE-2024-27980 fix and `execFileSync` applies no PATHEXT to a bare name. The plugin-uninstall line also interpolated a discovered plugin name into that shell string; the name is matched against `/^[a-z0-9][a-z0-9-]*$/` first, so nothing could reach it, but the guard and the interpolation sat in different functions and were the only thing making the line safe. All four calls are now argv lists through one `runCommand` helper, so shim resolution and the `cmd.exe` hop happen in one place and a name holding shell metacharacters stays a single argument.
+- Windows: `scripts/dev-install.js` resolved `claude` with `resolveExecutableForPlatform`, which maps the bare name to `claude.cmd` - the assumption #390 removed from `bin/cli.js` (#394). The npm global install does ship `claude.cmd`, but the native installer ships `claude.exe`, so `commandExists('claude')` passed while the spawn failed, and with both call sites discarding the error the marketplace removal and every plugin uninstall silently did nothing. The `where.exe`-based pick moved out of `bin/cli.js` into `lib/utils/claude-executable.js` so both callers get the same answer, and the discarded errors became a warning: a numeric exit status means `claude` ran and refused, which is normal for a best-effort removal, while a spawn failure (status `null` with an errno, or `cmd.exe` reporting 9009 for a command it could not launch) means it never ran and is worth a line.
+- Windows checkouts: `.gitattributes` pins text files to LF (#392). `generate-docs` compares generated sections byte-for-byte against the file on disk, so with Git's CRLF conversion every section read as stale and `--check` exited 1. The marketplace contract test read `scripts/plugins.txt` the same way, keeping a trailing `\r` on each name; it now tolerates CRLF so a checkout setting cannot masquerade as a mismatched plugin.
 - `lib/utils/command-parser.js` used a raw null byte where `'\0'` was intended. Git and grep classified the file as binary, so changes to it could not be reviewed as a diff. Also normalized to LF, the only CRLF-encoded source file in the repo.
+
+### Tests
+
+- The `planShimSpawn` tests faked the platform but not `COMSPEC`, so their assertions on a bare `cmd.exe` only held on a host where that variable is unset - the Windows runner reports `C:\Windows\system32\cmd.exe` and six of them failed on the first Windows CI run. `COMSPEC` is now faked alongside the platform, with cases for both the variable's value and the bare `cmd.exe` left when it is unset (#392).
 
 ## [6.0.1] - 2026-07-22
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,12 @@ AI models can write code. That's not the hard part anymore. The hard part is eve
 ---
 > Building custom skills, agents, hooks, or MCP tools? [agnix](https://github.com/agent-sh/agnix) is the CLI + LSP linter that catches config errors before they fail silently - real-time IDE validation, auto suggestions, auto-fix, and 423 rules for Claude Code, Codex, OpenCode, Cursor, Kiro, Copilot, Gemini CLI, Cline, Windsurf, Roo Code, Amp, and more.
 
-## What's New in 6.0.1
+## What's New in 6.0.2
 
-- Restores Cursor and Kiro installation after a shared-core regression.
-- Removes the unused vulnerable `js-yaml` production dependency.
+- Fixes Windows installs: the Claude Code executable is resolved with `where.exe` instead of an assumed `claude.cmd`, and `.cmd` shims are launched through `cmd.exe` at every spawn site.
+- `agentsys install` reports failures instead of printing success when Claude Code rejected a plugin, and exits non-zero.
+- Deletes the two adapter `install.sh` scripts, which deleted a working install and reported success; `agentsys --tool codex` / `--tool opencode` is the install path.
+- CI now runs the suite on Windows as well as Linux.
 
 ## What This Is
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentsys",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentsys",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "workspaces": [
         "lib"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsys",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "A modular runtime and orchestration system for AI agents - works with Claude Code, OpenCode, and Codex CLI",
   "main": "lib/platform/detect-platform.js",
   "type": "commonjs",

--- a/site/content.json
+++ b/site/content.json
@@ -5,7 +5,7 @@
     "url": "https://agent-sh.github.io/agentsys",
     "repo": "https://github.com/agent-sh/agentsys",
     "npm": "https://www.npmjs.com/package/agentsys",
-    "version": "6.0.1",
+    "version": "6.0.2",
     "author": "Avi Fenesh",
     "author_url": "https://github.com/avifenesh"
   },


### PR DESCRIPTION
Patch release cutting everything merged since v6.0.1 (#383, #385, #386, #387, #388, #390, #391, #392, #393, #394, #395).

## What this PR does

- `CHANGELOG.md`: `## [Unreleased]` becomes `## [6.0.2] - 2026-08-17`, with entries added for the merges that had none - the Windows CI leg and its `.gitattributes`/COMSPEC follow-ups (#392), the dependabot config (#385), the jest 30 bump and the `--testPathPatterns` checklist change (#387), the two lockfile security bumps (#383, #386), and the two dev-install fixes (#393, #394).
- `README.md`: "What's New" now describes 6.0.2.
- `npm run bump 6.0.2`: `package.json`, `package-lock.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `site/content.json`.

No source changes.

## Verification

- `npm test` - 89 suites, 3581 passed, 39 skipped.
- `npm run validate` - all validators pass.
- `node scripts/generate-docs.js --check` and `node scripts/gen-adapters.js --check` - both exit 0, so the stamped version is consistent with the generated docs.

Tagging `v6.0.2` after the merge is what publishes to npm and cuts the GitHub release.